### PR TITLE
Controllerモデルの戻り値を修正（next controller hiddenを追加)

### DIFF
--- a/src/models/abc/controller.py
+++ b/src/models/abc/controller.py
@@ -9,9 +9,9 @@ class Controller(nn.Module, ABC):
     r"""Abstract controller model class.
 
     This model gets `hidden`, `state`, `target` and `controller_hidden`,
-    after returns `action` in :meth:`forward`.
+    after returns `action` and `controller_hidden` in :meth:`forward`.
 
-        i.e. a_t ~ C(a_t | h_t, s_t, \tau_t, hc_t})
+        i.e. C(a_t | h_t, s_t, \tau_t, hc_t}) -> a_t, hc_{t+1}
 
     Note: action range is must be [-1, 1] for action normalization.
     """
@@ -24,7 +24,7 @@ class Controller(nn.Module, ABC):
         target: _tensor_or_any,
         controller_hidden: _tensor_or_any,
         probabilistic: bool,
-    ) -> _tensor_or_any:
+    ) -> tuple[_tensor_or_any, _tensor_or_any]:
         r"""Take action. If `probabilistic` is True, sampling from normal distribution.
 
         Args:
@@ -35,5 +35,6 @@ class Controller(nn.Module, ABC):
             probabilistic (bool): If True, sample action from normal distribution.
         Returns:
             action (_tensor_or_any): action data `a_t`. The value range must be [-1, 1].
+            next_controller_hidden (_tensor_or_any): Next controller hidden state `hc_{t+1}`.
         """
         pass

--- a/tests/models/abc/test_controller.py
+++ b/tests/models/abc/test_controller.py
@@ -21,8 +21,8 @@ def test_Controller():
             target: Tensor,
             controller_hidden: Tensor,
             probabilistic: bool,
-        ) -> Tensor:
-            return torch.randn(10)
+        ) -> tuple[Tensor, Tensor]:
+            return torch.randn(10), torch.randn(10)
 
     dummy = torch.randn(10)
     c = C()


### PR DESCRIPTION
## 概要
#23 のControllerモデルの修正

<!-- 変更の目的 もしくは 関連する Issue 番号 -->

## 変更内容
Controllerクラスの`forward`パスの返値に`next_controller_hidden` $hc_{t+1}$ を追加。
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲
- src/models/abc/controller.py
- tests/models/abc/test_controller.py

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
