### PR TITLE
Feature/#15conformer

### DIFF
--- a/src/models/components/conformer/attention.py
+++ b/src/models/components/conformer/attention.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # Copyright 2019 Shigeki Karita
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
@@ -11,6 +10,7 @@ import math
 import torch
 from torch import nn
 
+
 class MultiHeadedAttention(nn.Module):
     """Multi-Head Attention layer.
 
@@ -18,12 +18,11 @@ class MultiHeadedAttention(nn.Module):
         n_head (int): The number of heads.
         n_feat (int): The number of features.
         dropout_rate (float): Dropout rate.
-
     """
 
     def __init__(self, n_head, n_feat, dropout_rate):
         """Construct an MultiHeadedAttention object."""
-        super(MultiHeadedAttention, self).__init__()
+        super().__init__()
         assert n_feat % n_head == 0
         # We assume d_v always equals d_k
         self.d_k = n_feat // n_head
@@ -47,7 +46,6 @@ class MultiHeadedAttention(nn.Module):
             torch.Tensor: Transformed query tensor (#batch, n_head, time1, d_k).
             torch.Tensor: Transformed key tensor (#batch, n_head, time2, d_k).
             torch.Tensor: Transformed value tensor (#batch, n_head, time2, d_k).
-
         """
         n_batch = query.size(0)
         q = self.linear_q(query).view(n_batch, -1, self.h, self.d_k)
@@ -70,7 +68,6 @@ class MultiHeadedAttention(nn.Module):
         Returns:
             torch.Tensor: Transformed value (#batch, time1, d_model)
                 weighted by the attention score (#batch, time1, time2).
-
         """
         n_batch = value.size(0)
         if mask is not None:
@@ -103,11 +100,11 @@ class MultiHeadedAttention(nn.Module):
 
         Returns:
             torch.Tensor: Output tensor (#batch, time1, d_model).
-
         """
         q, k, v = self.forward_qkv(query, key, value)
         scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(self.d_k)
         return self.forward_attention(v, scores, mask)
+
 
 class LegacyRelPositionMultiHeadedAttention(MultiHeadedAttention):
     """Multi-Head Attention layer with relative position encoding (old version).
@@ -121,7 +118,6 @@ class LegacyRelPositionMultiHeadedAttention(MultiHeadedAttention):
         n_feat (int): The number of features.
         dropout_rate (float): Dropout rate.
         zero_triu (bool): Whether to zero the upper triangular part of attention matrix.
-
     """
 
     def __init__(self, n_head, n_feat, dropout_rate, zero_triu=False):
@@ -145,7 +141,6 @@ class LegacyRelPositionMultiHeadedAttention(MultiHeadedAttention):
 
         Returns:
             torch.Tensor: Output tensor.
-
         """
         zero_pad = torch.zeros((*x.size()[:3], 1), device=x.device, dtype=x.dtype)
         x_padded = torch.cat([zero_pad, x], dim=-1)
@@ -172,7 +167,6 @@ class LegacyRelPositionMultiHeadedAttention(MultiHeadedAttention):
 
         Returns:
             torch.Tensor: Output tensor (#batch, time1, d_model).
-
         """
         q, k, v = self.forward_qkv(query, key, value)
         q = q.transpose(1, 2)  # (batch, time1, head, d_k)
@@ -197,11 +191,10 @@ class LegacyRelPositionMultiHeadedAttention(MultiHeadedAttention):
         matrix_bd = torch.matmul(q_with_bias_v, p.transpose(-2, -1))
         matrix_bd = self.rel_shift(matrix_bd)
 
-        scores = (matrix_ac + matrix_bd) / math.sqrt(
-            self.d_k
-        )  # (batch, head, time1, time2)
+        scores = (matrix_ac + matrix_bd) / math.sqrt(self.d_k)  # (batch, head, time1, time2)
 
         return self.forward_attention(v, scores, mask)
+
 
 class RelPositionMultiHeadedAttention(MultiHeadedAttention):
     """Multi-Head Attention layer with relative position encoding (new implementation).
@@ -215,7 +208,6 @@ class RelPositionMultiHeadedAttention(MultiHeadedAttention):
         n_feat (int): The number of features.
         dropout_rate (float): Dropout rate.
         zero_triu (bool): Whether to zero the upper triangular part of attention matrix.
-
     """
 
     def __init__(self, n_head, n_feat, dropout_rate, zero_triu=False):
@@ -240,7 +232,6 @@ class RelPositionMultiHeadedAttention(MultiHeadedAttention):
 
         Returns:
             torch.Tensor: Output tensor.
-
         """
         zero_pad = torch.zeros((*x.size()[:3], 1), device=x.device, dtype=x.dtype)
         x_padded = torch.cat([zero_pad, x], dim=-1)
@@ -270,7 +261,6 @@ class RelPositionMultiHeadedAttention(MultiHeadedAttention):
 
         Returns:
             torch.Tensor: Output tensor (#batch, time1, d_model).
-
         """
         q, k, v = self.forward_qkv(query, key, value)
         q = q.transpose(1, 2)  # (batch, time1, head, d_k)
@@ -295,8 +285,6 @@ class RelPositionMultiHeadedAttention(MultiHeadedAttention):
         matrix_bd = torch.matmul(q_with_bias_v, p.transpose(-2, -1))
         matrix_bd = self.rel_shift(matrix_bd)
 
-        scores = (matrix_ac + matrix_bd) / math.sqrt(
-            self.d_k
-        )  # (batch, head, time1, time2)
+        scores = (matrix_ac + matrix_bd) / math.sqrt(self.d_k)  # (batch, head, time1, time2)
 
         return self.forward_attention(v, scores, mask)

--- a/src/models/components/conformer/attention.py
+++ b/src/models/components/conformer/attention.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 Shigeki Karita
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Multi-Head Attention layer definition."""
+
+import math
+
+import torch
+from torch import nn
+
+class MultiHeadedAttention(nn.Module):
+    """Multi-Head Attention layer.
+
+    Args:
+        n_head (int): The number of heads.
+        n_feat (int): The number of features.
+        dropout_rate (float): Dropout rate.
+
+    """
+
+    def __init__(self, n_head, n_feat, dropout_rate):
+        """Construct an MultiHeadedAttention object."""
+        super(MultiHeadedAttention, self).__init__()
+        assert n_feat % n_head == 0
+        # We assume d_v always equals d_k
+        self.d_k = n_feat // n_head
+        self.h = n_head
+        self.linear_q = nn.Linear(n_feat, n_feat)
+        self.linear_k = nn.Linear(n_feat, n_feat)
+        self.linear_v = nn.Linear(n_feat, n_feat)
+        self.linear_out = nn.Linear(n_feat, n_feat)
+        self.attn = None
+        self.dropout = nn.Dropout(p=dropout_rate)
+
+    def forward_qkv(self, query, key, value):
+        """Transform query, key and value.
+
+        Args:
+            query (torch.Tensor): Query tensor (#batch, time1, size).
+            key (torch.Tensor): Key tensor (#batch, time2, size).
+            value (torch.Tensor): Value tensor (#batch, time2, size).
+
+        Returns:
+            torch.Tensor: Transformed query tensor (#batch, n_head, time1, d_k).
+            torch.Tensor: Transformed key tensor (#batch, n_head, time2, d_k).
+            torch.Tensor: Transformed value tensor (#batch, n_head, time2, d_k).
+
+        """
+        n_batch = query.size(0)
+        q = self.linear_q(query).view(n_batch, -1, self.h, self.d_k)
+        k = self.linear_k(key).view(n_batch, -1, self.h, self.d_k)
+        v = self.linear_v(value).view(n_batch, -1, self.h, self.d_k)
+        q = q.transpose(1, 2)  # (batch, head, time1, d_k)
+        k = k.transpose(1, 2)  # (batch, head, time2, d_k)
+        v = v.transpose(1, 2)  # (batch, head, time2, d_k)
+
+        return q, k, v
+
+    def forward_attention(self, value, scores, mask):
+        """Compute attention context vector.
+
+        Args:
+            value (torch.Tensor): Transformed value (#batch, n_head, time2, d_k).
+            scores (torch.Tensor): Attention score (#batch, n_head, time1, time2).
+            mask (torch.Tensor): Mask (#batch, 1, time2) or (#batch, time1, time2).
+
+        Returns:
+            torch.Tensor: Transformed value (#batch, time1, d_model)
+                weighted by the attention score (#batch, time1, time2).
+
+        """
+        n_batch = value.size(0)
+        if mask is not None:
+            mask = mask.unsqueeze(1).eq(0)  # (batch, 1, *, time2)
+            min_value = torch.finfo(scores.dtype).min
+            scores = scores.masked_fill(mask, min_value)
+            self.attn = torch.softmax(scores, dim=-1).masked_fill(
+                mask, 0.0
+            )  # (batch, head, time1, time2)
+        else:
+            self.attn = torch.softmax(scores, dim=-1)  # (batch, head, time1, time2)
+
+        p_attn = self.dropout(self.attn)
+        x = torch.matmul(p_attn, value)  # (batch, head, time1, d_k)
+        x = (
+            x.transpose(1, 2).contiguous().view(n_batch, -1, self.h * self.d_k)
+        )  # (batch, time1, d_model)
+
+        return self.linear_out(x)  # (batch, time1, d_model)
+
+    def forward(self, query, key, value, mask):
+        """Compute scaled dot product attention.
+
+        Args:
+            query (torch.Tensor): Query tensor (#batch, time1, size).
+            key (torch.Tensor): Key tensor (#batch, time2, size).
+            value (torch.Tensor): Value tensor (#batch, time2, size).
+            mask (torch.Tensor): Mask tensor (#batch, 1, time2) or
+                (#batch, time1, time2).
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time1, d_model).
+
+        """
+        q, k, v = self.forward_qkv(query, key, value)
+        scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(self.d_k)
+        return self.forward_attention(v, scores, mask)
+
+class LegacyRelPositionMultiHeadedAttention(MultiHeadedAttention):
+    """Multi-Head Attention layer with relative position encoding (old version).
+
+    Details can be found in https://github.com/espnet/espnet/pull/2816.
+
+    Paper: https://arxiv.org/abs/1901.02860
+
+    Args:
+        n_head (int): The number of heads.
+        n_feat (int): The number of features.
+        dropout_rate (float): Dropout rate.
+        zero_triu (bool): Whether to zero the upper triangular part of attention matrix.
+
+    """
+
+    def __init__(self, n_head, n_feat, dropout_rate, zero_triu=False):
+        """Construct an RelPositionMultiHeadedAttention object."""
+        super().__init__(n_head, n_feat, dropout_rate)
+        self.zero_triu = zero_triu
+        # linear transformation for positional encoding
+        self.linear_pos = nn.Linear(n_feat, n_feat, bias=False)
+        # these two learnable bias are used in matrix c and matrix d
+        # as described in https://arxiv.org/abs/1901.02860 Section 3.3
+        self.pos_bias_u = nn.Parameter(torch.Tensor(self.h, self.d_k))
+        self.pos_bias_v = nn.Parameter(torch.Tensor(self.h, self.d_k))
+        torch.nn.init.xavier_uniform_(self.pos_bias_u)
+        torch.nn.init.xavier_uniform_(self.pos_bias_v)
+
+    def rel_shift(self, x):
+        """Compute relative positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, head, time1, time2).
+
+        Returns:
+            torch.Tensor: Output tensor.
+
+        """
+        zero_pad = torch.zeros((*x.size()[:3], 1), device=x.device, dtype=x.dtype)
+        x_padded = torch.cat([zero_pad, x], dim=-1)
+
+        x_padded = x_padded.view(*x.size()[:2], x.size(3) + 1, x.size(2))
+        x = x_padded[:, :, 1:].view_as(x)
+
+        if self.zero_triu:
+            ones = torch.ones((x.size(2), x.size(3)))
+            x = x * torch.tril(ones, x.size(3) - x.size(2))[None, None, :, :]
+
+        return x
+
+    def forward(self, query, key, value, pos_emb, mask):
+        """Compute 'Scaled Dot Product Attention' with rel. positional encoding.
+
+        Args:
+            query (torch.Tensor): Query tensor (#batch, time1, size).
+            key (torch.Tensor): Key tensor (#batch, time2, size).
+            value (torch.Tensor): Value tensor (#batch, time2, size).
+            pos_emb (torch.Tensor): Positional embedding tensor (#batch, time1, size).
+            mask (torch.Tensor): Mask tensor (#batch, 1, time2) or
+                (#batch, time1, time2).
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time1, d_model).
+
+        """
+        q, k, v = self.forward_qkv(query, key, value)
+        q = q.transpose(1, 2)  # (batch, time1, head, d_k)
+
+        n_batch_pos = pos_emb.size(0)
+        p = self.linear_pos(pos_emb).view(n_batch_pos, -1, self.h, self.d_k)
+        p = p.transpose(1, 2)  # (batch, head, time1, d_k)
+
+        # (batch, head, time1, d_k)
+        q_with_bias_u = (q + self.pos_bias_u).transpose(1, 2)
+        # (batch, head, time1, d_k)
+        q_with_bias_v = (q + self.pos_bias_v).transpose(1, 2)
+
+        # compute attention score
+        # first compute matrix a and matrix c
+        # as described in https://arxiv.org/abs/1901.02860 Section 3.3
+        # (batch, head, time1, time2)
+        matrix_ac = torch.matmul(q_with_bias_u, k.transpose(-2, -1))
+
+        # compute matrix b and matrix d
+        # (batch, head, time1, time1)
+        matrix_bd = torch.matmul(q_with_bias_v, p.transpose(-2, -1))
+        matrix_bd = self.rel_shift(matrix_bd)
+
+        scores = (matrix_ac + matrix_bd) / math.sqrt(
+            self.d_k
+        )  # (batch, head, time1, time2)
+
+        return self.forward_attention(v, scores, mask)
+
+class RelPositionMultiHeadedAttention(MultiHeadedAttention):
+    """Multi-Head Attention layer with relative position encoding (new implementation).
+
+    Details can be found in https://github.com/espnet/espnet/pull/2816.
+
+    Paper: https://arxiv.org/abs/1901.02860
+
+    Args:
+        n_head (int): The number of heads.
+        n_feat (int): The number of features.
+        dropout_rate (float): Dropout rate.
+        zero_triu (bool): Whether to zero the upper triangular part of attention matrix.
+
+    """
+
+    def __init__(self, n_head, n_feat, dropout_rate, zero_triu=False):
+        """Construct an RelPositionMultiHeadedAttention object."""
+        super().__init__(n_head, n_feat, dropout_rate)
+        self.zero_triu = zero_triu
+        # linear transformation for positional encoding
+        self.linear_pos = nn.Linear(n_feat, n_feat, bias=False)
+        # these two learnable bias are used in matrix c and matrix d
+        # as described in https://arxiv.org/abs/1901.02860 Section 3.3
+        self.pos_bias_u = nn.Parameter(torch.Tensor(self.h, self.d_k))
+        self.pos_bias_v = nn.Parameter(torch.Tensor(self.h, self.d_k))
+        torch.nn.init.xavier_uniform_(self.pos_bias_u)
+        torch.nn.init.xavier_uniform_(self.pos_bias_v)
+
+    def rel_shift(self, x):
+        """Compute relative positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, head, time1, 2*time1-1).
+            time1 means the length of query vector.
+
+        Returns:
+            torch.Tensor: Output tensor.
+
+        """
+        zero_pad = torch.zeros((*x.size()[:3], 1), device=x.device, dtype=x.dtype)
+        x_padded = torch.cat([zero_pad, x], dim=-1)
+
+        x_padded = x_padded.view(*x.size()[:2], x.size(3) + 1, x.size(2))
+        x = x_padded[:, :, 1:].view_as(x)[
+            :, :, :, : x.size(-1) // 2 + 1
+        ]  # only keep the positions from 0 to time2
+
+        if self.zero_triu:
+            ones = torch.ones((x.size(2), x.size(3)), device=x.device)
+            x = x * torch.tril(ones, x.size(3) - x.size(2))[None, None, :, :]
+
+        return x
+
+    def forward(self, query, key, value, pos_emb, mask):
+        """Compute 'Scaled Dot Product Attention' with rel. positional encoding.
+
+        Args:
+            query (torch.Tensor): Query tensor (#batch, time1, size).
+            key (torch.Tensor): Key tensor (#batch, time2, size).
+            value (torch.Tensor): Value tensor (#batch, time2, size).
+            pos_emb (torch.Tensor): Positional embedding tensor
+                (#batch, 2*time1-1, size).
+            mask (torch.Tensor): Mask tensor (#batch, 1, time2) or
+                (#batch, time1, time2).
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time1, d_model).
+
+        """
+        q, k, v = self.forward_qkv(query, key, value)
+        q = q.transpose(1, 2)  # (batch, time1, head, d_k)
+
+        n_batch_pos = pos_emb.size(0)
+        p = self.linear_pos(pos_emb).view(n_batch_pos, -1, self.h, self.d_k)
+        p = p.transpose(1, 2)  # (batch, head, 2*time1-1, d_k)
+
+        # (batch, head, time1, d_k)
+        q_with_bias_u = (q + self.pos_bias_u).transpose(1, 2)
+        # (batch, head, time1, d_k)
+        q_with_bias_v = (q + self.pos_bias_v).transpose(1, 2)
+
+        # compute attention score
+        # first compute matrix a and matrix c
+        # as described in https://arxiv.org/abs/1901.02860 Section 3.3
+        # (batch, head, time1, time2)
+        matrix_ac = torch.matmul(q_with_bias_u, k.transpose(-2, -1))
+
+        # compute matrix b and matrix d
+        # (batch, head, time1, 2*time1-1)
+        matrix_bd = torch.matmul(q_with_bias_v, p.transpose(-2, -1))
+        matrix_bd = self.rel_shift(matrix_bd)
+
+        scores = (matrix_ac + matrix_bd) / math.sqrt(
+            self.d_k
+        )  # (batch, head, time1, time2)
+
+        return self.forward_attention(v, scores, mask)

--- a/src/models/components/conformer/convolution.py
+++ b/src/models/components/conformer/convolution.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2020 Johns Hopkins University (Shinji Watanabe)
+#                Northwestern Polytechnical University (Pengcheng Guo)
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""ConvolutionModule definition."""
+
+from torch import nn
+
+
+class ConvolutionModule(nn.Module):
+    """ConvolutionModule in Conformer model.
+
+    Args:
+        channels (int): The number of channels of conv layers.
+        kernel_size (int): Kernerl size of conv layers.
+
+    """
+
+    def __init__(self, channels, kernel_size, activation=nn.ReLU(), bias=True):
+        """Construct an ConvolutionModule object."""
+        super(ConvolutionModule, self).__init__()
+        # kernerl_size should be a odd number for 'SAME' padding
+        assert (kernel_size - 1) % 2 == 0
+
+        self.pointwise_conv1 = nn.Conv1d(
+            channels,
+            2 * channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            bias=bias,
+        )
+        self.depthwise_conv = nn.Conv1d(
+            channels,
+            channels,
+            kernel_size,
+            stride=1,
+            padding=(kernel_size - 1) // 2,
+            groups=channels,
+            bias=bias,
+        )
+        self.norm = nn.BatchNorm1d(channels)
+        self.pointwise_conv2 = nn.Conv1d(
+            channels,
+            channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            bias=bias,
+        )
+        self.activation = activation
+
+    def forward(self, x):
+        """Compute convolution module.
+
+        Args:
+            x (torch.Tensor): Input tensor (#batch, time, channels).
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time, channels).
+
+        """
+        # exchange the temporal dimension and the feature dimension
+        x = x.transpose(1, 2)
+
+        # GLU mechanism
+        x = self.pointwise_conv1(x)  # (batch, 2*channel, dim)
+        x = nn.functional.glu(x, dim=1)  # (batch, channel, dim)
+
+        # 1D Depthwise Conv
+        x = self.depthwise_conv(x)
+        x = self.activation(self.norm(x))
+
+        x = self.pointwise_conv2(x)
+
+        return x.transpose(1, 2)

--- a/src/models/components/conformer/convolution.py
+++ b/src/models/components/conformer/convolution.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # Copyright 2020 Johns Hopkins University (Shinji Watanabe)
 #                Northwestern Polytechnical University (Pengcheng Guo)
@@ -15,13 +14,12 @@ class ConvolutionModule(nn.Module):
 
     Args:
         channels (int): The number of channels of conv layers.
-        kernel_size (int): Kernerl size of conv layers.
-
+        kernel_size (int): Kernel size of conv layers.
     """
 
     def __init__(self, channels, kernel_size, activation=nn.ReLU(), bias=True):
         """Construct an ConvolutionModule object."""
-        super(ConvolutionModule, self).__init__()
+        super().__init__()
         # kernerl_size should be a odd number for 'SAME' padding
         assert (kernel_size - 1) % 2 == 0
 
@@ -61,7 +59,6 @@ class ConvolutionModule(nn.Module):
 
         Returns:
             torch.Tensor: Output tensor (#batch, time, channels).
-
         """
         # exchange the temporal dimension and the feature dimension
         x = x.transpose(1, 2)

--- a/src/models/components/conformer/embedding.py
+++ b/src/models/components/conformer/embedding.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 Shigeki Karita
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Positional Encoding Module."""
+
+import math
+
+import torch
+
+
+def _pre_hook(
+    state_dict,
+    prefix,
+    local_metadata,
+    strict,
+    missing_keys,
+    unexpected_keys,
+    error_msgs,
+):
+    """Perform pre-hook in load_state_dict for backward compatibility.
+
+    Note:
+        We saved self.pe until v.0.5.2 but we have omitted it later.
+        Therefore, we remove the item "pe" from `state_dict` for backward compatibility.
+
+    """
+    k = prefix + "pe"
+    if k in state_dict:
+        state_dict.pop(k)
+
+
+class PositionalEncoding(torch.nn.Module):
+    """Positional encoding.
+
+    Args:
+        d_model (int): Embedding dimension.
+        dropout_rate (float): Dropout rate.
+        max_len (int): Maximum input length.
+        reverse (bool): Whether to reverse the input position. Only for
+        the class LegacyRelPositionalEncoding. We remove it in the current
+        class RelPositionalEncoding.
+    """
+
+    def __init__(self, d_model, dropout_rate, max_len=5000, reverse=False):
+        """Construct an PositionalEncoding object."""
+        super(PositionalEncoding, self).__init__()
+        self.d_model = d_model
+        self.reverse = reverse
+        self.xscale = math.sqrt(self.d_model)
+        self.dropout = torch.nn.Dropout(p=dropout_rate)
+        self.pe = None
+        self.extend_pe(torch.tensor(0.0).expand(1, max_len))
+        self._register_load_state_dict_pre_hook(_pre_hook)
+
+    def extend_pe(self, x):
+        """Reset the positional encodings."""
+        if self.pe is not None:
+            if self.pe.size(1) >= x.size(1):
+                if self.pe.dtype != x.dtype or self.pe.device != x.device:
+                    self.pe = self.pe.to(dtype=x.dtype, device=x.device)
+                return
+        pe = torch.zeros(x.size(1), self.d_model)
+        if self.reverse:
+            position = torch.arange(
+                x.size(1) - 1, -1, -1.0, dtype=torch.float32
+            ).unsqueeze(1)
+        else:
+            position = torch.arange(0, x.size(1), dtype=torch.float32).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, self.d_model, 2, dtype=torch.float32)
+            * -(math.log(10000.0) / self.d_model)
+        )
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0)
+        self.pe = pe.to(device=x.device, dtype=x.dtype)
+
+    def forward(self, x: torch.Tensor):
+        """Add positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, time, `*`).
+
+        Returns:
+            torch.Tensor: Encoded tensor (batch, time, `*`).
+        """
+        self.extend_pe(x)
+        x = x * self.xscale + self.pe[:, : x.size(1)]
+        return self.dropout(x)
+
+
+class ScaledPositionalEncoding(PositionalEncoding):
+    """Scaled positional encoding module.
+
+    See Sec. 3.2  https://arxiv.org/abs/1809.08895
+
+    Args:
+        d_model (int): Embedding dimension.
+        dropout_rate (float): Dropout rate.
+        max_len (int): Maximum input length.
+
+    """
+
+    def __init__(self, d_model, dropout_rate, max_len=5000):
+        """Initialize class."""
+        super().__init__(d_model=d_model, dropout_rate=dropout_rate, max_len=max_len)
+        self.alpha = torch.nn.Parameter(torch.tensor(1.0))
+
+    def reset_parameters(self):
+        """Reset parameters."""
+        self.alpha.data = torch.tensor(1.0)
+
+    def forward(self, x):
+        """Add positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, time, `*`).
+
+        Returns:
+            torch.Tensor: Encoded tensor (batch, time, `*`).
+
+        """
+        self.extend_pe(x)
+        x = x + self.alpha * self.pe[:, : x.size(1)]
+        return self.dropout(x)
+
+
+class LearnableFourierPosEnc(torch.nn.Module):
+    """Learnable Fourier Features for Positional Encoding.
+
+    See https://arxiv.org/pdf/2106.02795.pdf
+
+    Args:
+        d_model (int): Embedding dimension.
+        dropout_rate (float): Dropout rate.
+        max_len (int): Maximum input length.
+        gamma (float): init parameter for the positional kernel variance
+            see https://arxiv.org/pdf/2106.02795.pdf.
+        apply_scaling (bool): Whether to scale the input before adding the pos encoding.
+        hidden_dim (int): if not None, we modulate the pos encodings with
+            an MLP whose hidden layer has hidden_dim neurons.
+    """
+
+    def __init__(
+        self,
+        d_model,
+        dropout_rate=0.0,
+        max_len=5000,
+        gamma=1.0,
+        apply_scaling=False,
+        hidden_dim=None,
+    ):
+        """Initialize class."""
+        super(LearnableFourierPosEnc, self).__init__()
+
+        self.d_model = d_model
+
+        if apply_scaling:
+            self.xscale = math.sqrt(self.d_model)
+        else:
+            self.xscale = 1.0
+
+        self.dropout = torch.nn.Dropout(dropout_rate)
+        self.max_len = max_len
+
+        self.gamma = gamma
+        if self.gamma is None:
+            self.gamma = self.d_model // 2
+
+        assert (
+            d_model % 2 == 0
+        ), "d_model should be divisible by two in order to use this layer."
+        self.w_r = torch.nn.Parameter(torch.empty(1, d_model // 2))
+        self._reset()  # init the weights
+
+        self.hidden_dim = hidden_dim
+        if self.hidden_dim is not None:
+            self.mlp = torch.nn.Sequential(
+                torch.nn.Linear(d_model, hidden_dim),
+                torch.nn.GELU(),
+                torch.nn.Linear(hidden_dim, d_model),
+            )
+
+    def _reset(self):
+        self.w_r.data = torch.normal(
+            0, (1 / math.sqrt(self.gamma)), (1, self.d_model // 2)
+        )
+
+    def extend_pe(self, x):
+        """Reset the positional encodings."""
+        position_v = torch.arange(0, x.size(1), dtype=torch.float32).unsqueeze(1).to(x)
+
+        cosine = torch.cos(torch.matmul(position_v, self.w_r))
+        sine = torch.sin(torch.matmul(position_v, self.w_r))
+        pos_enc = torch.cat((cosine, sine), -1)
+        pos_enc /= math.sqrt(self.d_model)
+
+        if self.hidden_dim is None:
+            return pos_enc.unsqueeze(0)
+        else:
+            return self.mlp(pos_enc.unsqueeze(0))
+
+    def forward(self, x: torch.Tensor):
+        """Add positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, time, `*`).
+
+        Returns:
+            torch.Tensor: Encoded tensor (batch, time, `*`).
+        """
+        pe = self.extend_pe(x)
+        x = x * self.xscale + pe
+        return self.dropout(x)
+
+
+class LegacyRelPositionalEncoding(PositionalEncoding):
+    """Relative positional encoding module (old version).
+
+    Details can be found in https://github.com/espnet/espnet/pull/2816.
+
+    See : Appendix B in https://arxiv.org/abs/1901.02860
+
+    Args:
+        d_model (int): Embedding dimension.
+        dropout_rate (float): Dropout rate.
+        max_len (int): Maximum input length.
+
+    """
+
+    def __init__(self, d_model, dropout_rate, max_len=5000):
+        """Initialize class."""
+        super().__init__(
+            d_model=d_model,
+            dropout_rate=dropout_rate,
+            max_len=max_len,
+            reverse=True,
+        )
+
+    def forward(self, x):
+        """Compute positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, time, `*`).
+
+        Returns:
+            torch.Tensor: Encoded tensor (batch, time, `*`).
+            torch.Tensor: Positional embedding tensor (1, time, `*`).
+
+        """
+        self.extend_pe(x)
+        x = x * self.xscale
+        pos_emb = self.pe[:, : x.size(1)]
+        return self.dropout(x), self.dropout(pos_emb)
+
+
+class RelPositionalEncoding(torch.nn.Module):
+    """Relative positional encoding module (new implementation).
+
+    Details can be found in https://github.com/espnet/espnet/pull/2816.
+
+    See : Appendix B in https://arxiv.org/abs/1901.02860
+
+    Args:
+        d_model (int): Embedding dimension.
+        dropout_rate (float): Dropout rate.
+        max_len (int): Maximum input length.
+
+    """
+
+    def __init__(self, d_model, dropout_rate, max_len=5000):
+        """Construct an PositionalEncoding object."""
+        super(RelPositionalEncoding, self).__init__()
+        self.d_model = d_model
+        self.xscale = math.sqrt(self.d_model)
+        self.dropout = torch.nn.Dropout(p=dropout_rate)
+        self.pe = None
+        self.extend_pe(torch.tensor(0.0).expand(1, max_len))
+
+    def extend_pe(self, x):
+        """Reset the positional encodings."""
+        if self.pe is not None:
+            # self.pe contains both positive and negative parts
+            # the length of self.pe is 2 * input_len - 1
+            if self.pe.size(1) >= x.size(1) * 2 - 1:
+                if self.pe.dtype != x.dtype or self.pe.device != x.device:
+                    self.pe = self.pe.to(dtype=x.dtype, device=x.device)
+                return
+        # Suppose `i` means to the position of query vecotr and `j` means the
+        # position of key vector. We use position relative positions when keys
+        # are to the left (i>j) and negative relative positions otherwise (i<j).
+        pe_positive = torch.zeros(x.size(1), self.d_model)
+        pe_negative = torch.zeros(x.size(1), self.d_model)
+        position = torch.arange(0, x.size(1), dtype=torch.float32).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, self.d_model, 2, dtype=torch.float32)
+            * -(math.log(10000.0) / self.d_model)
+        )
+        pe_positive[:, 0::2] = torch.sin(position * div_term)
+        pe_positive[:, 1::2] = torch.cos(position * div_term)
+        pe_negative[:, 0::2] = torch.sin(-1 * position * div_term)
+        pe_negative[:, 1::2] = torch.cos(-1 * position * div_term)
+
+        # Reserve the order of positive indices and concat both positive and
+        # negative indices. This is used to support the shifting trick
+        # as in https://arxiv.org/abs/1901.02860
+        pe_positive = torch.flip(pe_positive, [0]).unsqueeze(0)
+        pe_negative = pe_negative[1:].unsqueeze(0)
+        pe = torch.cat([pe_positive, pe_negative], dim=1)
+        self.pe = pe.to(device=x.device, dtype=x.dtype)
+
+    def forward(self, x: torch.Tensor):
+        """Add positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, time, `*`).
+
+        Returns:
+            torch.Tensor: Encoded tensor (batch, time, `*`).
+
+        """
+        self.extend_pe(x)
+        x = x * self.xscale
+        pos_emb = self.pe[
+            :,
+            self.pe.size(1) // 2 - x.size(1) + 1 : self.pe.size(1) // 2 + x.size(1),
+        ]
+        return self.dropout(x), self.dropout(pos_emb)
+
+
+class StreamPositionalEncoding(torch.nn.Module):
+    """Streaming Positional encoding.
+
+    Args:
+        d_model (int): Embedding dimension.
+        dropout_rate (float): Dropout rate.
+        max_len (int): Maximum input length.
+
+    """
+
+    def __init__(self, d_model, dropout_rate, max_len=5000):
+        """Construct an PositionalEncoding object."""
+        super(StreamPositionalEncoding, self).__init__()
+        self.d_model = d_model
+        self.xscale = math.sqrt(self.d_model)
+        self.dropout = torch.nn.Dropout(p=dropout_rate)
+        self.pe = None
+        self.tmp = torch.tensor(0.0).expand(1, max_len)
+        self.extend_pe(self.tmp.size(1), self.tmp.device, self.tmp.dtype)
+        self._register_load_state_dict_pre_hook(_pre_hook)
+
+    def extend_pe(self, length, device, dtype):
+        """Reset the positional encodings."""
+        if self.pe is not None:
+            if self.pe.size(1) >= length:
+                if self.pe.dtype != dtype or self.pe.device != device:
+                    self.pe = self.pe.to(dtype=dtype, device=device)
+                return
+        pe = torch.zeros(length, self.d_model)
+        position = torch.arange(0, length, dtype=torch.float32).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, self.d_model, 2, dtype=torch.float32)
+            * -(math.log(10000.0) / self.d_model)
+        )
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0)
+        self.pe = pe.to(device=device, dtype=dtype)
+
+    def forward(self, x: torch.Tensor, start_idx: int = 0):
+        """Add positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, time, `*`).
+
+        Returns:
+            torch.Tensor: Encoded tensor (batch, time, `*`).
+
+        """
+        self.extend_pe(x.size(1) + start_idx, x.device, x.dtype)
+        x = x * self.xscale + self.pe[:, start_idx : start_idx + x.size(1)]
+        return self.dropout(x)

--- a/src/models/components/conformer/embedding.py
+++ b/src/models/components/conformer/embedding.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # Copyright 2019 Shigeki Karita
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
@@ -25,7 +24,6 @@ def _pre_hook(
     Note:
         We saved self.pe until v.0.5.2 but we have omitted it later.
         Therefore, we remove the item "pe" from `state_dict` for backward compatibility.
-
     """
     k = prefix + "pe"
     if k in state_dict:
@@ -46,7 +44,7 @@ class PositionalEncoding(torch.nn.Module):
 
     def __init__(self, d_model, dropout_rate, max_len=5000, reverse=False):
         """Construct an PositionalEncoding object."""
-        super(PositionalEncoding, self).__init__()
+        super().__init__()
         self.d_model = d_model
         self.reverse = reverse
         self.xscale = math.sqrt(self.d_model)
@@ -64,9 +62,7 @@ class PositionalEncoding(torch.nn.Module):
                 return
         pe = torch.zeros(x.size(1), self.d_model)
         if self.reverse:
-            position = torch.arange(
-                x.size(1) - 1, -1, -1.0, dtype=torch.float32
-            ).unsqueeze(1)
+            position = torch.arange(x.size(1) - 1, -1, -1.0, dtype=torch.float32).unsqueeze(1)
         else:
             position = torch.arange(0, x.size(1), dtype=torch.float32).unsqueeze(1)
         div_term = torch.exp(
@@ -101,7 +97,6 @@ class ScaledPositionalEncoding(PositionalEncoding):
         d_model (int): Embedding dimension.
         dropout_rate (float): Dropout rate.
         max_len (int): Maximum input length.
-
     """
 
     def __init__(self, d_model, dropout_rate, max_len=5000):
@@ -121,7 +116,6 @@ class ScaledPositionalEncoding(PositionalEncoding):
 
         Returns:
             torch.Tensor: Encoded tensor (batch, time, `*`).
-
         """
         self.extend_pe(x)
         x = x + self.alpha * self.pe[:, : x.size(1)]
@@ -154,7 +148,7 @@ class LearnableFourierPosEnc(torch.nn.Module):
         hidden_dim=None,
     ):
         """Initialize class."""
-        super(LearnableFourierPosEnc, self).__init__()
+        super().__init__()
 
         self.d_model = d_model
 
@@ -170,9 +164,7 @@ class LearnableFourierPosEnc(torch.nn.Module):
         if self.gamma is None:
             self.gamma = self.d_model // 2
 
-        assert (
-            d_model % 2 == 0
-        ), "d_model should be divisible by two in order to use this layer."
+        assert d_model % 2 == 0, "d_model should be divisible by two in order to use this layer."
         self.w_r = torch.nn.Parameter(torch.empty(1, d_model // 2))
         self._reset()  # init the weights
 
@@ -185,9 +177,7 @@ class LearnableFourierPosEnc(torch.nn.Module):
             )
 
     def _reset(self):
-        self.w_r.data = torch.normal(
-            0, (1 / math.sqrt(self.gamma)), (1, self.d_model // 2)
-        )
+        self.w_r.data = torch.normal(0, (1 / math.sqrt(self.gamma)), (1, self.d_model // 2))
 
     def extend_pe(self, x):
         """Reset the positional encodings."""
@@ -228,7 +218,6 @@ class LegacyRelPositionalEncoding(PositionalEncoding):
         d_model (int): Embedding dimension.
         dropout_rate (float): Dropout rate.
         max_len (int): Maximum input length.
-
     """
 
     def __init__(self, d_model, dropout_rate, max_len=5000):
@@ -249,7 +238,6 @@ class LegacyRelPositionalEncoding(PositionalEncoding):
         Returns:
             torch.Tensor: Encoded tensor (batch, time, `*`).
             torch.Tensor: Positional embedding tensor (1, time, `*`).
-
         """
         self.extend_pe(x)
         x = x * self.xscale
@@ -268,12 +256,11 @@ class RelPositionalEncoding(torch.nn.Module):
         d_model (int): Embedding dimension.
         dropout_rate (float): Dropout rate.
         max_len (int): Maximum input length.
-
     """
 
     def __init__(self, d_model, dropout_rate, max_len=5000):
         """Construct an PositionalEncoding object."""
-        super(RelPositionalEncoding, self).__init__()
+        super().__init__()
         self.d_model = d_model
         self.xscale = math.sqrt(self.d_model)
         self.dropout = torch.nn.Dropout(p=dropout_rate)
@@ -289,7 +276,7 @@ class RelPositionalEncoding(torch.nn.Module):
                 if self.pe.dtype != x.dtype or self.pe.device != x.device:
                     self.pe = self.pe.to(dtype=x.dtype, device=x.device)
                 return
-        # Suppose `i` means to the position of query vecotr and `j` means the
+        # Suppose `i` means to the position of query vector and `j` means the
         # position of key vector. We use position relative positions when keys
         # are to the left (i>j) and negative relative positions otherwise (i<j).
         pe_positive = torch.zeros(x.size(1), self.d_model)
@@ -320,7 +307,6 @@ class RelPositionalEncoding(torch.nn.Module):
 
         Returns:
             torch.Tensor: Encoded tensor (batch, time, `*`).
-
         """
         self.extend_pe(x)
         x = x * self.xscale
@@ -338,12 +324,11 @@ class StreamPositionalEncoding(torch.nn.Module):
         d_model (int): Embedding dimension.
         dropout_rate (float): Dropout rate.
         max_len (int): Maximum input length.
-
     """
 
     def __init__(self, d_model, dropout_rate, max_len=5000):
         """Construct an PositionalEncoding object."""
-        super(StreamPositionalEncoding, self).__init__()
+        super().__init__()
         self.d_model = d_model
         self.xscale = math.sqrt(self.d_model)
         self.dropout = torch.nn.Dropout(p=dropout_rate)
@@ -378,7 +363,6 @@ class StreamPositionalEncoding(torch.nn.Module):
 
         Returns:
             torch.Tensor: Encoded tensor (batch, time, `*`).
-
         """
         self.extend_pe(x.size(1) + start_idx, x.device, x.dtype)
         x = x * self.xscale + self.pe[:, start_idx : start_idx + x.size(1)]

--- a/src/models/components/conformer/encoder.py
+++ b/src/models/components/conformer/encoder.py
@@ -1,0 +1,243 @@
+# Copyright 2020 Johns Hopkins University (Shinji Watanabe)
+#                Northwestern Polytechnical University (Pengcheng Guo)
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Encoder definition."""
+
+import torch
+
+from .convolution import ConvolutionModule
+from .encoder_layer import EncoderLayer
+from ....utils.nets_utils import get_activation
+from .attention import (
+    LegacyRelPositionMultiHeadedAttention,RelPositionMultiHeadedAttention
+)
+
+from .embedding import (
+    LegacyRelPositionalEncoding,
+    RelPositionalEncoding
+)
+from .layer_norm import LayerNorm
+from .multi_layer_conv import MultiLayeredConv1d
+from .repeat import repeat
+
+
+class Encoder(torch.nn.Module):
+    """Conformer encoder module.
+
+    Args:
+        idim (int): Input dimension.
+        attention_dim (int): Dimension of attention.
+        attention_heads (int): The number of heads of multi head attention.
+        linear_units (int): The number of units of position-wise feed forward.
+        num_blocks (int): The number of decoder blocks.
+        dropout_rate (float): Dropout rate.
+        positional_dropout_rate (float): Dropout rate after adding positional encoding.
+        attention_dropout_rate (float): Dropout rate in attention.
+        input_layer (Union[str, torch.nn.Module]): Input layer type.
+        normalize_before (bool): Whether to use layer_norm before the first block.
+        concat_after (bool): Whether to concat attention layer's input and output.
+            if True, additional linear will be applied.
+            i.e. x -> x + linear(concat(x, att(x)))
+            if False, no additional linear will be applied. i.e. x -> x + att(x)
+        positionwise_layer_type (str): "linear", "conv1d", or "conv1d-linear".
+        positionwise_conv_kernel_size (int): Kernel size of positionwise conv1d layer.
+        macaron_style (bool): Whether to use macaron style for positionwise layer.
+        pos_enc_layer_type (str): Encoder positional encoding layer type.
+        selfattention_layer_type (str): Encoder attention layer type.
+        activation_type (str): Encoder activation function type.
+        use_cnn_module (bool): Whether to use convolution module.
+        zero_triu (bool): Whether to zero the upper triangular part of attention matrix.
+        cnn_module_kernel (int): Kernerl size of convolution module.
+        padding_idx (int): Padding idx for input_layer=embed.
+        stochastic_depth_rate (float): Maximum probability to skip the encoder layer.
+        intermediate_layers (Union[List[int], None]): indices of intermediate CTC layer.
+            indices start from 1.
+            if not None, intermediate outputs are returned (which changes return type
+            signature.)
+
+    """
+
+    def __init__(
+        self,
+        idim,
+        attention_dim=256,
+        attention_heads=4,
+        linear_units=2048,
+        num_blocks=6,
+        dropout_rate=0.1,
+        positional_dropout_rate=0.1,
+        attention_dropout_rate=0.0,
+        input_layer=None,
+        normalize_before=True,
+        concat_after=False,
+        positionwise_layer_type="conv1d",
+        positionwise_conv_kernel_size=1,
+        macaron_style=True,
+        pos_enc_layer_type="legacy_rel_pos",
+        selfattention_layer_type="legacy_rel_selfattn",
+        activation_type="swish",
+        use_cnn_module=False,
+        zero_triu=False,
+        cnn_module_kernel=31,
+        padding_idx=-1,
+        stochastic_depth_rate=0.0,
+        intermediate_layers=None,
+        ctc_softmax=None,
+        conditioning_layer_dim=None,
+    ):
+        """Construct an Encoder object."""
+        super(Encoder, self).__init__()
+
+        activation = get_activation(activation_type)
+        if pos_enc_layer_type == "legacy_rel_pos":
+            pos_enc_class = LegacyRelPositionalEncoding
+            assert selfattention_layer_type == "legacy_rel_selfattn"
+        elif pos_enc_layer_type == "rel_pos":
+            assert selfattention_layer_type == "rel_selfattn"
+            pos_enc_class = RelPositionalEncoding
+        else:
+            raise ValueError("unknown pos_enc_layer: " + pos_enc_layer_type)
+
+        self.conv_subsampling_factor = 1
+        if input_layer == "linear":
+            self.embed = torch.nn.Sequential(
+                torch.nn.Linear(idim, attention_dim),
+                torch.nn.LayerNorm(attention_dim),
+                torch.nn.Dropout(dropout_rate),
+                pos_enc_class(attention_dim, positional_dropout_rate),
+            )
+        elif input_layer == "embed":
+            self.embed = torch.nn.Sequential(
+                torch.nn.Embedding(idim, attention_dim, padding_idx=padding_idx),
+                pos_enc_class(attention_dim, positional_dropout_rate),
+            )
+        elif isinstance(input_layer, torch.nn.Module):
+            self.embed = torch.nn.Sequential(
+                input_layer,
+                pos_enc_class(attention_dim, positional_dropout_rate),
+            )
+        elif input_layer is None:
+            self.embed = torch.nn.Sequential(
+                pos_enc_class(attention_dim, positional_dropout_rate)
+            )
+        else:
+            raise ValueError("unknown input_layer: " + input_layer)
+        self.normalize_before = normalize_before
+
+        # self-attention module definition
+        if selfattention_layer_type == "legacy_rel_selfattn":
+            assert pos_enc_layer_type == "legacy_rel_pos"
+            encoder_selfattn_layer = LegacyRelPositionMultiHeadedAttention
+            encoder_selfattn_layer_args = (
+                attention_heads,
+                attention_dim,
+                attention_dropout_rate,
+            )
+        elif selfattention_layer_type == "rel_selfattn":
+            assert pos_enc_layer_type == "rel_pos"
+            encoder_selfattn_layer = RelPositionMultiHeadedAttention
+            encoder_selfattn_layer_args = (
+                attention_heads,
+                attention_dim,
+                attention_dropout_rate,
+                zero_triu,
+            )
+        else:
+            raise ValueError("unknown encoder_attn_layer: " + selfattention_layer_type)
+
+        # feed-forward module definition
+        if positionwise_layer_type == "conv1d":
+            positionwise_layer = MultiLayeredConv1d
+            positionwise_layer_args = (
+                attention_dim,
+                linear_units,
+                positionwise_conv_kernel_size,
+                dropout_rate,
+            )
+        else:
+            raise NotImplementedError("Support only linear or conv1d.")
+
+        # convolution module definition
+        convolution_layer = ConvolutionModule
+        convolution_layer_args = (attention_dim, cnn_module_kernel, activation)
+
+        self.encoders = repeat(
+            num_blocks,
+            lambda lnum: EncoderLayer(
+                attention_dim,
+                encoder_selfattn_layer(*encoder_selfattn_layer_args),
+                positionwise_layer(*positionwise_layer_args),
+                positionwise_layer(*positionwise_layer_args) if macaron_style else None,
+                convolution_layer(*convolution_layer_args) if use_cnn_module else None,
+                dropout_rate,
+                normalize_before,
+                concat_after,
+                stochastic_depth_rate * float(1 + lnum) / num_blocks,
+            ),
+        )
+        if self.normalize_before:
+            self.after_norm = LayerNorm(attention_dim)
+
+        self.intermediate_layers = intermediate_layers
+        self.use_conditioning = True if ctc_softmax is not None else False
+        if self.use_conditioning:
+            self.ctc_softmax = ctc_softmax
+            self.conditioning_layer = torch.nn.Linear(
+                conditioning_layer_dim, attention_dim
+            )
+
+    def forward(self, xs, masks):
+        """Encode input sequence.
+
+        Args:
+            xs (torch.Tensor): Input tensor (#batch, time, idim).
+            masks (torch.Tensor): Mask tensor (#batch, time).
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time, attention_dim).
+            torch.Tensor: Mask tensor (#batch, time).
+
+        """
+        xs = self.embed(xs)
+
+        if self.intermediate_layers is None:
+            xs, masks = self.encoders(xs, masks)
+        else:
+            intermediate_outputs = []
+            for layer_idx, encoder_layer in enumerate(self.encoders):
+                xs, masks = encoder_layer(xs, masks)
+
+                if (
+                    self.intermediate_layers is not None
+                    and layer_idx + 1 in self.intermediate_layers
+                ):
+                    # intermediate branches also require normalization.
+                    encoder_output = xs
+                    if isinstance(encoder_output, tuple):
+                        encoder_output = encoder_output[0]
+
+                    if self.normalize_before:
+                        encoder_output = self.after_norm(encoder_output)
+
+                    intermediate_outputs.append(encoder_output)
+
+                    if self.use_conditioning:
+                        intermediate_result = self.ctc_softmax(encoder_output)
+
+                        if isinstance(xs, tuple):
+                            x, pos_emb = xs[0], xs[1]
+                            x = x + self.conditioning_layer(intermediate_result)
+                            xs = (x, pos_emb)
+                        else:
+                            xs = xs + self.conditioning_layer(intermediate_result)
+
+        if isinstance(xs, tuple):
+            xs = xs[0]
+
+        if self.normalize_before:
+            xs = self.after_norm(xs)
+
+        if self.intermediate_layers is not None:
+            return xs, masks, intermediate_outputs
+        return xs, masks

--- a/src/models/components/conformer/encoder.py
+++ b/src/models/components/conformer/encoder.py
@@ -6,17 +6,14 @@
 
 import torch
 
-from .convolution import ConvolutionModule
-from .encoder_layer import EncoderLayer
 from ....utils.nets_utils import get_activation
 from .attention import (
-    LegacyRelPositionMultiHeadedAttention,RelPositionMultiHeadedAttention
+    LegacyRelPositionMultiHeadedAttention,
+    RelPositionMultiHeadedAttention,
 )
-
-from .embedding import (
-    LegacyRelPositionalEncoding,
-    RelPositionalEncoding
-)
+from .convolution import ConvolutionModule
+from .embedding import LegacyRelPositionalEncoding, RelPositionalEncoding
+from .encoder_layer import EncoderLayer
 from .layer_norm import LayerNorm
 from .multi_layer_conv import MultiLayeredConv1d
 from .repeat import repeat
@@ -48,14 +45,13 @@ class Encoder(torch.nn.Module):
         activation_type (str): Encoder activation function type.
         use_cnn_module (bool): Whether to use convolution module.
         zero_triu (bool): Whether to zero the upper triangular part of attention matrix.
-        cnn_module_kernel (int): Kernerl size of convolution module.
+        cnn_module_kernel (int): Kernel size of convolution module.
         padding_idx (int): Padding idx for input_layer=embed.
         stochastic_depth_rate (float): Maximum probability to skip the encoder layer.
         intermediate_layers (Union[List[int], None]): indices of intermediate CTC layer.
             indices start from 1.
             if not None, intermediate outputs are returned (which changes return type
             signature.)
-
     """
 
     def __init__(
@@ -87,7 +83,7 @@ class Encoder(torch.nn.Module):
         conditioning_layer_dim=None,
     ):
         """Construct an Encoder object."""
-        super(Encoder, self).__init__()
+        super().__init__()
 
         activation = get_activation(activation_type)
         if pos_enc_layer_type == "legacy_rel_pos":
@@ -118,9 +114,7 @@ class Encoder(torch.nn.Module):
                 pos_enc_class(attention_dim, positional_dropout_rate),
             )
         elif input_layer is None:
-            self.embed = torch.nn.Sequential(
-                pos_enc_class(attention_dim, positional_dropout_rate)
-            )
+            self.embed = torch.nn.Sequential(pos_enc_class(attention_dim, positional_dropout_rate))
         else:
             raise ValueError("unknown input_layer: " + input_layer)
         self.normalize_before = normalize_before
@@ -183,9 +177,7 @@ class Encoder(torch.nn.Module):
         self.use_conditioning = True if ctc_softmax is not None else False
         if self.use_conditioning:
             self.ctc_softmax = ctc_softmax
-            self.conditioning_layer = torch.nn.Linear(
-                conditioning_layer_dim, attention_dim
-            )
+            self.conditioning_layer = torch.nn.Linear(conditioning_layer_dim, attention_dim)
 
     def forward(self, xs, masks):
         """Encode input sequence.
@@ -197,7 +189,6 @@ class Encoder(torch.nn.Module):
         Returns:
             torch.Tensor: Output tensor (#batch, time, attention_dim).
             torch.Tensor: Mask tensor (#batch, time).
-
         """
         xs = self.embed(xs)
 

--- a/src/models/components/conformer/encoder_layer.py
+++ b/src/models/components/conformer/encoder_layer.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2020 Johns Hopkins University (Shinji Watanabe)
+#                Northwestern Polytechnical University (Pengcheng Guo)
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Encoder self-attention layer definition."""
+
+import torch
+from torch import nn
+
+from .layer_norm import LayerNorm
+
+
+class EncoderLayer(nn.Module):
+    """Encoder layer module.
+
+    Args:
+        size (int): Input dimension.
+        self_attn (torch.nn.Module): Self-attention module instance.
+            `MultiHeadedAttention` or `RelPositionMultiHeadedAttention` instance
+            can be used as the argument.
+        feed_forward (torch.nn.Module): Feed-forward module instance.
+            `PositionwiseFeedForward`, `MultiLayeredConv1d`, or `Conv1dLinear` instance
+            can be used as the argument.
+        feed_forward_macaron (torch.nn.Module): Additional feed-forward module instance.
+            `PositionwiseFeedForward`, `MultiLayeredConv1d`, or `Conv1dLinear` instance
+            can be used as the argument.
+        conv_module (torch.nn.Module): Convolution module instance.
+            `ConvlutionModule` instance can be used as the argument.
+        dropout_rate (float): Dropout rate.
+        normalize_before (bool): Whether to use layer_norm before the first block.
+        concat_after (bool): Whether to concat attention layer's input and output.
+            if True, additional linear will be applied.
+            i.e. x -> x + linear(concat(x, att(x)))
+            if False, no additional linear will be applied. i.e. x -> x + att(x)
+        stochastic_depth_rate (float): Proability to skip this layer.
+            During training, the layer may skip residual computation and return input
+            as-is with given probability.
+    """
+
+    def __init__(
+        self,
+        size,
+        self_attn,
+        feed_forward,
+        feed_forward_macaron,
+        conv_module,
+        dropout_rate,
+        normalize_before=True,
+        concat_after=False,
+        stochastic_depth_rate=0.0,
+    ):
+        """Construct an EncoderLayer object."""
+        super(EncoderLayer, self).__init__()
+        self.self_attn = self_attn
+        self.feed_forward = feed_forward
+        self.feed_forward_macaron = feed_forward_macaron
+        self.conv_module = conv_module
+        self.norm_ff = LayerNorm(size)  # for the FNN module
+        self.norm_mha = LayerNorm(size)  # for the MHA module
+        if feed_forward_macaron is not None:
+            self.norm_ff_macaron = LayerNorm(size)
+            self.ff_scale = 0.5
+        else:
+            self.ff_scale = 1.0
+        if self.conv_module is not None:
+            self.norm_conv = LayerNorm(size)  # for the CNN module
+            self.norm_final = LayerNorm(size)  # for the final output of the block
+        self.dropout = nn.Dropout(dropout_rate)
+        self.size = size
+        self.normalize_before = normalize_before
+        self.concat_after = concat_after
+        if self.concat_after:
+            self.concat_linear = nn.Linear(size + size, size)
+        self.stochastic_depth_rate = stochastic_depth_rate
+
+    def forward(self, x_input, mask, cache=None):
+        """Compute encoded features.
+
+        Args:
+            x_input (Union[Tuple, torch.Tensor]): Input tensor w/ or w/o pos emb.
+                - w/ pos emb: Tuple of tensors [(#batch, time, size), (1, time, size)].
+                - w/o pos emb: Tensor (#batch, time, size).
+            mask (torch.Tensor): Mask tensor for the input (#batch, time).
+            cache (torch.Tensor): Cache tensor of the input (#batch, time - 1, size).
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time, size).
+            torch.Tensor: Mask tensor (#batch, time).
+
+        """
+        if isinstance(x_input, tuple):
+            x, pos_emb = x_input[0], x_input[1]
+        else:
+            x, pos_emb = x_input, None
+
+        skip_layer = False
+        # with stochastic depth, residual connection `x + f(x)` becomes
+        # `x <- x + 1 / (1 - p) * f(x)` at training time.
+        stoch_layer_coeff = 1.0
+        if self.training and self.stochastic_depth_rate > 0:
+            skip_layer = torch.rand(1).item() < self.stochastic_depth_rate
+            stoch_layer_coeff = 1.0 / (1 - self.stochastic_depth_rate)
+
+        if skip_layer:
+            if cache is not None:
+                x = torch.cat([cache, x], dim=1)
+            if pos_emb is not None:
+                return (x, pos_emb), mask
+            return x, mask
+
+        # whether to use macaron style
+        if self.feed_forward_macaron is not None:
+            residual = x
+            if self.normalize_before:
+                x = self.norm_ff_macaron(x)
+            x = residual + stoch_layer_coeff * self.ff_scale * self.dropout(
+                self.feed_forward_macaron(x)
+            )
+            if not self.normalize_before:
+                x = self.norm_ff_macaron(x)
+
+        # multi-headed self-attention module
+        residual = x
+        if self.normalize_before:
+            x = self.norm_mha(x)
+
+        if cache is None:
+            x_q = x
+        else:
+            assert cache.shape == (x.shape[0], x.shape[1] - 1, self.size)
+            x_q = x[:, -1:, :]
+            residual = residual[:, -1:, :]
+            mask = None if mask is None else mask[:, -1:, :]
+
+        if pos_emb is not None:
+            x_att = self.self_attn(x_q, x, x, pos_emb, mask)
+        else:
+            x_att = self.self_attn(x_q, x, x, mask)
+
+        if self.concat_after:
+            x_concat = torch.cat((x, x_att), dim=-1)
+            x = residual + stoch_layer_coeff * self.concat_linear(x_concat)
+        else:
+            x = residual + stoch_layer_coeff * self.dropout(x_att)
+        if not self.normalize_before:
+            x = self.norm_mha(x)
+
+        # convolution module
+        if self.conv_module is not None:
+            residual = x
+            if self.normalize_before:
+                x = self.norm_conv(x)
+            x = residual + stoch_layer_coeff * self.dropout(self.conv_module(x))
+            if not self.normalize_before:
+                x = self.norm_conv(x)
+
+        # feed forward module
+        residual = x
+        if self.normalize_before:
+            x = self.norm_ff(x)
+        x = residual + stoch_layer_coeff * self.ff_scale * self.dropout(
+            self.feed_forward(x)
+        )
+        if not self.normalize_before:
+            x = self.norm_ff(x)
+
+        if self.conv_module is not None:
+            x = self.norm_final(x)
+
+        if cache is not None:
+            x = torch.cat([cache, x], dim=1)
+
+        if pos_emb is not None:
+            return (x, pos_emb), mask
+
+        return x, mask

--- a/src/models/components/conformer/encoder_layer.py
+++ b/src/models/components/conformer/encoder_layer.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # Copyright 2020 Johns Hopkins University (Shinji Watanabe)
 #                Northwestern Polytechnical University (Pengcheng Guo)
@@ -53,7 +52,7 @@ class EncoderLayer(nn.Module):
         stochastic_depth_rate=0.0,
     ):
         """Construct an EncoderLayer object."""
-        super(EncoderLayer, self).__init__()
+        super().__init__()
         self.self_attn = self_attn
         self.feed_forward = feed_forward
         self.feed_forward_macaron = feed_forward_macaron
@@ -89,7 +88,6 @@ class EncoderLayer(nn.Module):
         Returns:
             torch.Tensor: Output tensor (#batch, time, size).
             torch.Tensor: Mask tensor (#batch, time).
-
         """
         if isinstance(x_input, tuple):
             x, pos_emb = x_input[0], x_input[1]
@@ -161,9 +159,7 @@ class EncoderLayer(nn.Module):
         residual = x
         if self.normalize_before:
             x = self.norm_ff(x)
-        x = residual + stoch_layer_coeff * self.ff_scale * self.dropout(
-            self.feed_forward(x)
-        )
+        x = residual + stoch_layer_coeff * self.ff_scale * self.dropout(self.feed_forward(x))
         if not self.normalize_before:
             x = self.norm_ff(x)
 

--- a/src/models/components/conformer/layer_norm.py
+++ b/src/models/components/conformer/layer_norm.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 Shigeki Karita
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+# espnetから移植したモジュール
+"""Layer normalization module."""
+
+import torch
+
+
+class LayerNorm(torch.nn.LayerNorm):
+    """
+    Layer normalization module.
+    軸が指定できるように拡張したもの
+
+    Args:
+        nout (int): Output dim size.
+        dim (int): Dimension to be normalized.
+
+    """
+
+    def __init__(self, nout, dim=-1):
+        """Construct an LayerNorm object."""
+        super(LayerNorm, self).__init__(nout, eps=1e-12)
+        self.dim = dim
+
+    def forward(self, x):
+        """Apply layer normalization.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Normalized tensor.
+
+        """
+        if self.dim == -1:
+            return super(LayerNorm, self).forward(x)
+        return (
+            super(LayerNorm, self)
+            .forward(x.transpose(self.dim, -1))
+            .transpose(self.dim, -1)
+        )

--- a/src/models/components/conformer/layer_norm.py
+++ b/src/models/components/conformer/layer_norm.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # Copyright 2019 Shigeki Karita
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
@@ -10,19 +9,16 @@ import torch
 
 
 class LayerNorm(torch.nn.LayerNorm):
-    """
-    Layer normalization module.
-    軸が指定できるように拡張したもの
+    """Layer normalization module. 軸が指定できるように拡張したもの.
 
     Args:
         nout (int): Output dim size.
         dim (int): Dimension to be normalized.
-
     """
 
     def __init__(self, nout, dim=-1):
         """Construct an LayerNorm object."""
-        super(LayerNorm, self).__init__(nout, eps=1e-12)
+        super().__init__(nout, eps=1e-12)
         self.dim = dim
 
     def forward(self, x):
@@ -33,12 +29,7 @@ class LayerNorm(torch.nn.LayerNorm):
 
         Returns:
             torch.Tensor: Normalized tensor.
-
         """
         if self.dim == -1:
-            return super(LayerNorm, self).forward(x)
-        return (
-            super(LayerNorm, self)
-            .forward(x.transpose(self.dim, -1))
-            .transpose(self.dim, -1)
-        )
+            return super().forward(x)
+        return super().forward(x.transpose(self.dim, -1)).transpose(self.dim, -1)

--- a/src/models/components/conformer/multi_layer_conv.py
+++ b/src/models/components/conformer/multi_layer_conv.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # Copyright 2019 Tomoki Hayashi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
@@ -19,7 +18,6 @@ class MultiLayeredConv1d(torch.nn.Module):
 
     .. _`FastSpeech: Fast, Robust and Controllable Text to Speech`:
         https://arxiv.org/pdf/1905.09263.pdf
-
     """
 
     def __init__(self, in_chans, hidden_chans, kernel_size, dropout_rate):
@@ -30,9 +28,8 @@ class MultiLayeredConv1d(torch.nn.Module):
             hidden_chans (int): Number of hidden channels.
             kernel_size (int): Kernel size of conv1d.
             dropout_rate (float): Dropout rate.
-
         """
-        super(MultiLayeredConv1d, self).__init__()
+        super().__init__()
         self.w_1 = torch.nn.Conv1d(
             in_chans,
             hidden_chans,
@@ -57,16 +54,15 @@ class MultiLayeredConv1d(torch.nn.Module):
 
         Returns:
             torch.Tensor: Batch of output tensors (B, T, hidden_chans).
-
         """
         x = torch.relu(self.w_1(x.transpose(-1, 1))).transpose(-1, 1)
         return self.w_2(self.dropout(x).transpose(-1, 1)).transpose(-1, 1)
+
 
 class Conv1dLinear(torch.nn.Module):
     """Conv1D + Linear for Transformer block.
 
     A variant of MultiLayeredConv1d, which replaces second conv-layer to linear.
-
     """
 
     def __init__(self, in_chans, hidden_chans, kernel_size, dropout_rate):
@@ -77,9 +73,8 @@ class Conv1dLinear(torch.nn.Module):
             hidden_chans (int): Number of hidden channels.
             kernel_size (int): Kernel size of conv1d.
             dropout_rate (float): Dropout rate.
-
         """
-        super(Conv1dLinear, self).__init__()
+        super().__init__()
         self.w_1 = torch.nn.Conv1d(
             in_chans,
             hidden_chans,
@@ -98,7 +93,6 @@ class Conv1dLinear(torch.nn.Module):
 
         Returns:
             torch.Tensor: Batch of output tensors (B, T, hidden_chans).
-
         """
         x = torch.relu(self.w_1(x.transpose(-1, 1))).transpose(-1, 1)
         return self.w_2(self.dropout(x))

--- a/src/models/components/conformer/multi_layer_conv.py
+++ b/src/models/components/conformer/multi_layer_conv.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 Tomoki Hayashi
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Layer modules for FFT block in FastSpeech (Feed-forward Transformer)."""
+
+import torch
+
+
+class MultiLayeredConv1d(torch.nn.Module):
+    """Multi-layered conv1d for Transformer block.
+
+    This is a module of multi-leyered conv1d designed
+    to replace positionwise feed-forward network
+    in Transforner block, which is introduced in
+    `FastSpeech: Fast, Robust and Controllable Text to Speech`_.
+
+    .. _`FastSpeech: Fast, Robust and Controllable Text to Speech`:
+        https://arxiv.org/pdf/1905.09263.pdf
+
+    """
+
+    def __init__(self, in_chans, hidden_chans, kernel_size, dropout_rate):
+        """Initialize MultiLayeredConv1d module.
+
+        Args:
+            in_chans (int): Number of input channels.
+            hidden_chans (int): Number of hidden channels.
+            kernel_size (int): Kernel size of conv1d.
+            dropout_rate (float): Dropout rate.
+
+        """
+        super(MultiLayeredConv1d, self).__init__()
+        self.w_1 = torch.nn.Conv1d(
+            in_chans,
+            hidden_chans,
+            kernel_size,
+            stride=1,
+            padding=(kernel_size - 1) // 2,
+        )
+        self.w_2 = torch.nn.Conv1d(
+            hidden_chans,
+            in_chans,
+            kernel_size,
+            stride=1,
+            padding=(kernel_size - 1) // 2,
+        )
+        self.dropout = torch.nn.Dropout(dropout_rate)
+
+    def forward(self, x):
+        """Calculate forward propagation.
+
+        Args:
+            x (torch.Tensor): Batch of input tensors (B, T, in_chans).
+
+        Returns:
+            torch.Tensor: Batch of output tensors (B, T, hidden_chans).
+
+        """
+        x = torch.relu(self.w_1(x.transpose(-1, 1))).transpose(-1, 1)
+        return self.w_2(self.dropout(x).transpose(-1, 1)).transpose(-1, 1)
+
+class Conv1dLinear(torch.nn.Module):
+    """Conv1D + Linear for Transformer block.
+
+    A variant of MultiLayeredConv1d, which replaces second conv-layer to linear.
+
+    """
+
+    def __init__(self, in_chans, hidden_chans, kernel_size, dropout_rate):
+        """Initialize Conv1dLinear module.
+
+        Args:
+            in_chans (int): Number of input channels.
+            hidden_chans (int): Number of hidden channels.
+            kernel_size (int): Kernel size of conv1d.
+            dropout_rate (float): Dropout rate.
+
+        """
+        super(Conv1dLinear, self).__init__()
+        self.w_1 = torch.nn.Conv1d(
+            in_chans,
+            hidden_chans,
+            kernel_size,
+            stride=1,
+            padding=(kernel_size - 1) // 2,
+        )
+        self.w_2 = torch.nn.Linear(hidden_chans, in_chans)
+        self.dropout = torch.nn.Dropout(dropout_rate)
+
+    def forward(self, x):
+        """Calculate forward propagation.
+
+        Args:
+            x (torch.Tensor): Batch of input tensors (B, T, in_chans).
+
+        Returns:
+            torch.Tensor: Batch of output tensors (B, T, hidden_chans).
+
+        """
+        x = torch.relu(self.w_1(x.transpose(-1, 1))).transpose(-1, 1)
+        return self.w_2(self.dropout(x))

--- a/src/models/components/conformer/postnet.py
+++ b/src/models/components/conformer/postnet.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 Nagoya University (Tomoki Hayashi)
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Tacotron2 decoder related modules."""
+
+import six
+import torch
+import torch.nn.functional as F
+
+class Postnet(torch.nn.Module):
+    """Postnet module for Spectrogram prediction network.
+    This is a module of Postnet in Spectrogram prediction network,
+    which described in `Natural TTS Synthesis by
+    Conditioning WaveNet on Mel Spectrogram Predictions`_.
+    The Postnet predicts refines the predicted
+    Mel-filterbank of the decoder,
+    which helps to compensate the detail structure of spectrogram.
+    .. _`Natural TTS Synthesis by Conditioning WaveNet on Mel Spectrogram Predictions`:
+       https://arxiv.org/abs/1712.05884
+    """
+
+    def __init__(
+        self,
+        idim,
+        odim,
+        n_layers=5,
+        n_chans=512,
+        n_filts=5,
+        dropout_rate=0.5,
+        use_batch_norm=True,
+    ):
+        """Initialize postnet module.
+        Args:
+            idim (int): Dimension of the inputs.
+            odim (int): Dimension of the outputs.
+            n_layers (int, optional): The number of layers.
+            n_filts (int, optional): The number of filter size.
+            n_units (int, optional): The number of filter channels.
+            use_batch_norm (bool, optional): Whether to use batch normalization..
+            dropout_rate (float, optional): Dropout rate..
+        """
+        super(Postnet, self).__init__()
+        self.postnet = torch.nn.ModuleList()
+        for layer in six.moves.range(n_layers - 1):
+            ichans = odim if layer == 0 else n_chans
+            ochans = odim if layer == n_layers - 1 else n_chans
+            if use_batch_norm:
+                self.postnet += [
+                    torch.nn.Sequential(
+                        torch.nn.Conv1d(
+                            ichans,
+                            ochans,
+                            n_filts,
+                            stride=1,
+                            padding=(n_filts - 1) // 2,
+                            bias=False,
+                        ),
+                        torch.nn.BatchNorm1d(ochans),
+                        torch.nn.Tanh(),
+                        torch.nn.Dropout(dropout_rate),
+                    )
+                ]
+            else:
+                self.postnet += [
+                    torch.nn.Sequential(
+                        torch.nn.Conv1d(
+                            ichans,
+                            ochans,
+                            n_filts,
+                            stride=1,
+                            padding=(n_filts - 1) // 2,
+                            bias=False,
+                        ),
+                        torch.nn.Tanh(),
+                        torch.nn.Dropout(dropout_rate),
+                    )
+                ]
+        ichans = n_chans if n_layers != 1 else odim
+        if use_batch_norm:
+            self.postnet += [
+                torch.nn.Sequential(
+                    torch.nn.Conv1d(
+                        ichans,
+                        odim,
+                        n_filts,
+                        stride=1,
+                        padding=(n_filts - 1) // 2,
+                        bias=False,
+                    ),
+                    torch.nn.BatchNorm1d(odim),
+                    torch.nn.Dropout(dropout_rate),
+                )
+            ]
+        else:
+            self.postnet += [
+                torch.nn.Sequential(
+                    torch.nn.Conv1d(
+                        ichans,
+                        odim,
+                        n_filts,
+                        stride=1,
+                        padding=(n_filts - 1) // 2,
+                        bias=False,
+                    ),
+                    torch.nn.Dropout(dropout_rate),
+                )
+            ]
+
+    def forward(self, xs):
+        """Calculate forward propagation.
+        Args:
+            xs (Tensor): Batch of the sequences of padded input tensors (B, idim, Tmax).
+        Returns:
+            Tensor: Batch of padded output tensor. (B, odim, Tmax).
+        """
+        for i in six.moves.range(len(self.postnet)):
+            xs = self.postnet[i](xs)
+        return xs

--- a/src/models/components/conformer/postnet.py
+++ b/src/models/components/conformer/postnet.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # Copyright 2019 Nagoya University (Tomoki Hayashi)
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
@@ -10,16 +9,15 @@ import six
 import torch
 import torch.nn.functional as F
 
+
 class Postnet(torch.nn.Module):
-    """Postnet module for Spectrogram prediction network.
-    This is a module of Postnet in Spectrogram prediction network,
-    which described in `Natural TTS Synthesis by
-    Conditioning WaveNet on Mel Spectrogram Predictions`_.
-    The Postnet predicts refines the predicted
-    Mel-filterbank of the decoder,
-    which helps to compensate the detail structure of spectrogram.
+    """Postnet module for Spectrogram prediction network. This is a module of Postnet in
+    Spectrogram prediction network, which described in `Natural TTS Synthesis by Conditioning
+    WaveNet on Mel Spectrogram Predictions`_. The Postnet predicts refines the predicted Mel-
+    filterbank of the decoder, which helps to compensate the detail structure of spectrogram.
+
     .. _`Natural TTS Synthesis by Conditioning WaveNet on Mel Spectrogram Predictions`:
-       https://arxiv.org/abs/1712.05884
+    https://arxiv.org/abs/1712.05884
     """
 
     def __init__(
@@ -33,6 +31,7 @@ class Postnet(torch.nn.Module):
         use_batch_norm=True,
     ):
         """Initialize postnet module.
+
         Args:
             idim (int): Dimension of the inputs.
             odim (int): Dimension of the outputs.
@@ -42,9 +41,9 @@ class Postnet(torch.nn.Module):
             use_batch_norm (bool, optional): Whether to use batch normalization..
             dropout_rate (float, optional): Dropout rate..
         """
-        super(Postnet, self).__init__()
+        super().__init__()
         self.postnet = torch.nn.ModuleList()
-        for layer in six.moves.range(n_layers - 1):
+        for layer in range(n_layers - 1):
             ichans = odim if layer == 0 else n_chans
             ochans = odim if layer == n_layers - 1 else n_chans
             if use_batch_norm:
@@ -111,11 +110,12 @@ class Postnet(torch.nn.Module):
 
     def forward(self, xs):
         """Calculate forward propagation.
+
         Args:
             xs (Tensor): Batch of the sequences of padded input tensors (B, idim, Tmax).
         Returns:
             Tensor: Batch of padded output tensor. (B, odim, Tmax).
         """
-        for i in six.moves.range(len(self.postnet)):
+        for i in range(len(self.postnet)):
             xs = self.postnet[i](xs)
         return xs

--- a/src/models/components/conformer/repeat.py
+++ b/src/models/components/conformer/repeat.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 Shigeki Karita
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Repeat the same layer definition."""
+
+import torch
+
+class MultiSequential(torch.nn.Sequential):
+    """Multi-input multi-output torch.nn.Sequential."""
+
+    def forward(self, *args):
+        """Repeat."""
+        for m in self:
+            args = m(*args)
+        return args
+
+def repeat(N, fn):
+    """Repeat module N times.
+
+    Args:
+        N (int): Number of repeat time.
+        fn (Callable): Function to generate module.
+
+    Returns:
+        MultiSequential: Repeated model instance.
+
+    """
+    return MultiSequential(*[fn(n) for n in range(N)])

--- a/src/models/components/conformer/repeat.py
+++ b/src/models/components/conformer/repeat.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # Copyright 2019 Shigeki Karita
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
@@ -7,6 +6,7 @@
 """Repeat the same layer definition."""
 
 import torch
+
 
 class MultiSequential(torch.nn.Sequential):
     """Multi-input multi-output torch.nn.Sequential."""
@@ -17,6 +17,7 @@ class MultiSequential(torch.nn.Sequential):
             args = m(*args)
         return args
 
+
 def repeat(N, fn):
     """Repeat module N times.
 
@@ -26,6 +27,5 @@ def repeat(N, fn):
 
     Returns:
         MultiSequential: Repeated model instance.
-
     """
     return MultiSequential(*[fn(n) for n in range(N)])

--- a/src/models/components/conformer/swish.py
+++ b/src/models/components/conformer/swish.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2020 Johns Hopkins University (Shinji Watanabe)
+#                Northwestern Polytechnical University (Pengcheng Guo)
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Swish() activation function for Conformer."""
+
+import torch
+
+
+class Swish(torch.nn.Module):
+    """Construct an Swish object."""
+
+    def forward(self, x):
+        """Return Swich activation function."""
+        return x * torch.sigmoid(x)

--- a/src/models/components/conformer/swish.py
+++ b/src/models/components/conformer/swish.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # Copyright 2020 Johns Hopkins University (Shinji Watanabe)
 #                Northwestern Polytechnical University (Pengcheng Guo)
@@ -14,5 +13,5 @@ class Swish(torch.nn.Module):
     """Construct an Swish object."""
 
     def forward(self, x):
-        """Return Swich activation function."""
+        """Return Swish activation function."""
         return x * torch.sigmoid(x)

--- a/src/models/components/conformer_decoder_fastspeech2.py
+++ b/src/models/components/conformer_decoder_fastspeech2.py
@@ -1,0 +1,142 @@
+
+from typing import Dict, Optional, Sequence, Tuple
+
+import torch
+
+from ...utils.nets_utils import make_non_pad_mask
+from .conformer.encoder import Encoder as ConformerEncoder
+from .conformer.postnet import Postnet
+
+class ConformerDecoder(torch.nn.Module):
+
+    def __init__(
+        self,
+        idim:int,
+        odim:int,
+        adim: int = 384,
+        aheads: int = 4,
+        layers: int = 6,
+        units: int = 1536,
+        postnet_layers: int = 5,
+        postnet_chans: int = 512,
+        postnet_filts: int = 5,
+        postnet_dropout_rate: float = 0.5,
+        positionwise_layer_type: str = "conv1d",
+        positionwise_conv_kernel_size: int = 1,
+        use_batch_norm: bool = True,
+        dropout_rate: float = 0.1,
+        positional_dropout_rate: float = 0.1,
+        attn_dropout_rate: float = 0.1,
+        normalize_before: bool = True,
+        concat_after: bool = False,
+        reduction_factor: int = 1,
+        use_macaron_style: bool = True,
+        pos_enc_layer_type: str = "rel_pos",
+        self_attn_layer_type: str = "rel_selfattn",
+        activation_type: str = "swish",
+        use_cnn_module: bool = True,
+        cnn_module_kernel_size: int = 31,
+    ):
+        super().__init__()
+        # store hyperparameters
+        self.idim = idim
+        self.odim = odim
+        self.eos = idim - 1
+        self.reduction_factor = reduction_factor
+
+        self.decoder = ConformerEncoder(
+                idim=0,
+                attention_dim=adim,
+                attention_heads=aheads,
+                linear_units=units,
+                num_blocks=layers,
+                input_layer=None,
+                dropout_rate=dropout_rate,
+                positional_dropout_rate=positional_dropout_rate,
+                attention_dropout_rate=attn_dropout_rate,
+                normalize_before=normalize_before,
+                concat_after=concat_after,
+                positionwise_layer_type=positionwise_layer_type,
+                positionwise_conv_kernel_size=positionwise_conv_kernel_size,
+                macaron_style=use_macaron_style,
+                pos_enc_layer_type=pos_enc_layer_type,
+                selfattention_layer_type=self_attn_layer_type,
+                activation_type=activation_type,
+                use_cnn_module=use_cnn_module,
+                cnn_module_kernel=cnn_module_kernel_size,
+            )
+    # define final projection
+        self.feat_out = torch.nn.Linear(adim, odim * reduction_factor)
+
+    # define postnet
+        self.postnet = (
+            None
+            if postnet_layers == 0
+            else Postnet(
+                idim=idim,
+                odim=odim,
+                n_layers=postnet_layers,
+                n_chans=postnet_chans,
+                n_filts=postnet_filts,
+                use_batch_norm=use_batch_norm,
+                dropout_rate=postnet_dropout_rate,
+            )
+        )
+    
+    def forward(
+        self,
+        feats: torch.Tensor,
+        feats_lengths: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor], torch.Tensor]:
+        """Calculate forward propagation.
+
+        Args:
+            feats (Tensor): Batch of padded target features (B, odim, feats_T).
+            feats_lengths (LongTensor): Batch of the lengths of each target (B,).
+
+        Returns:
+
+        """
+        # VITS posterior_encoderのshapeの違いを吸収
+        feats = feats.transpose(1,2)
+
+        if feats_lengths is not None:
+            h_masks = self._source_mask(feats_lengths)
+        else:
+            h_masks = None
+
+        zs, _ = self.decoder(feats, h_masks)  # (B, T_feats, adim)
+        before_outs = self.feat_out(zs).view(
+            zs.size(0), -1, self.odim
+        )  # (B, T_feats, odim)
+
+        # postnet -> (B, T_feats//r * r, odim)
+        if self.postnet is None:
+            after_outs = before_outs
+        else:
+            after_outs = before_outs + self.postnet(
+                before_outs.transpose(1, 2)
+            ).transpose(1, 2)
+        
+        return after_outs.transpose(1,2) # vitsとの違いを吸収
+
+    def _source_mask(self, ilens: torch.Tensor) -> torch.Tensor:
+        """Make masks for self-attention.
+
+        Args:
+            ilens (LongTensor): Batch of lengths (B,).
+
+        Returns:
+            Tensor: Mask tensor for self-attention.
+                dtype=torch.uint8 in PyTorch 1.2-
+                dtype=torch.bool in PyTorch 1.2+ (including 1.2)
+
+        Examples:
+            >>> ilens = [5, 3]
+            >>> self._source_mask(ilens)
+            tensor([[[1, 1, 1, 1, 1],
+                     [1, 1, 1, 0, 0]]], dtype=torch.uint8)
+
+        """
+        x_masks = make_non_pad_mask(ilens).to(next(self.parameters()).device)
+        return x_masks.unsqueeze(-2)

--- a/src/models/components/conformer_decoder_fastspeech2.py
+++ b/src/models/components/conformer_decoder_fastspeech2.py
@@ -1,4 +1,3 @@
-
 from typing import Dict, Optional, Sequence, Tuple
 
 import torch
@@ -7,12 +6,12 @@ from ...utils.nets_utils import make_non_pad_mask
 from .conformer.encoder import Encoder as ConformerEncoder
 from .conformer.postnet import Postnet
 
-class ConformerDecoder(torch.nn.Module):
 
+class ConformerDecoder(torch.nn.Module):
     def __init__(
         self,
-        idim:int,
-        odim:int,
+        idim: int,
+        odim: int,
         adim: int = 384,
         aheads: int = 4,
         layers: int = 6,
@@ -45,30 +44,30 @@ class ConformerDecoder(torch.nn.Module):
         self.reduction_factor = reduction_factor
 
         self.decoder = ConformerEncoder(
-                idim=0,
-                attention_dim=adim,
-                attention_heads=aheads,
-                linear_units=units,
-                num_blocks=layers,
-                input_layer=None,
-                dropout_rate=dropout_rate,
-                positional_dropout_rate=positional_dropout_rate,
-                attention_dropout_rate=attn_dropout_rate,
-                normalize_before=normalize_before,
-                concat_after=concat_after,
-                positionwise_layer_type=positionwise_layer_type,
-                positionwise_conv_kernel_size=positionwise_conv_kernel_size,
-                macaron_style=use_macaron_style,
-                pos_enc_layer_type=pos_enc_layer_type,
-                selfattention_layer_type=self_attn_layer_type,
-                activation_type=activation_type,
-                use_cnn_module=use_cnn_module,
-                cnn_module_kernel=cnn_module_kernel_size,
-            )
-    # define final projection
+            idim=0,
+            attention_dim=adim,
+            attention_heads=aheads,
+            linear_units=units,
+            num_blocks=layers,
+            input_layer=None,
+            dropout_rate=dropout_rate,
+            positional_dropout_rate=positional_dropout_rate,
+            attention_dropout_rate=attn_dropout_rate,
+            normalize_before=normalize_before,
+            concat_after=concat_after,
+            positionwise_layer_type=positionwise_layer_type,
+            positionwise_conv_kernel_size=positionwise_conv_kernel_size,
+            macaron_style=use_macaron_style,
+            pos_enc_layer_type=pos_enc_layer_type,
+            selfattention_layer_type=self_attn_layer_type,
+            activation_type=activation_type,
+            use_cnn_module=use_cnn_module,
+            cnn_module_kernel=cnn_module_kernel_size,
+        )
+        # define final projection
         self.feat_out = torch.nn.Linear(adim, odim * reduction_factor)
 
-    # define postnet
+        # define postnet
         self.postnet = (
             None
             if postnet_layers == 0
@@ -82,7 +81,7 @@ class ConformerDecoder(torch.nn.Module):
                 dropout_rate=postnet_dropout_rate,
             )
         )
-    
+
     def forward(
         self,
         feats: torch.Tensor,
@@ -95,10 +94,9 @@ class ConformerDecoder(torch.nn.Module):
             feats_lengths (LongTensor): Batch of the lengths of each target (B,).
 
         Returns:
-
         """
         # VITS posterior_encoderのshapeの違いを吸収
-        feats = feats.transpose(1,2)
+        feats = feats.transpose(1, 2)
 
         if feats_lengths is not None:
             h_masks = self._source_mask(feats_lengths)
@@ -106,19 +104,15 @@ class ConformerDecoder(torch.nn.Module):
             h_masks = None
 
         zs, _ = self.decoder(feats, h_masks)  # (B, T_feats, adim)
-        before_outs = self.feat_out(zs).view(
-            zs.size(0), -1, self.odim
-        )  # (B, T_feats, odim)
+        before_outs = self.feat_out(zs).view(zs.size(0), -1, self.odim)  # (B, T_feats, odim)
 
         # postnet -> (B, T_feats//r * r, odim)
         if self.postnet is None:
             after_outs = before_outs
         else:
-            after_outs = before_outs + self.postnet(
-                before_outs.transpose(1, 2)
-            ).transpose(1, 2)
-        
-        return after_outs.transpose(1,2) # vitsとの違いを吸収
+            after_outs = before_outs + self.postnet(before_outs.transpose(1, 2)).transpose(1, 2)
+
+        return after_outs.transpose(1, 2)  # vitsとの違いを吸収
 
     def _source_mask(self, ilens: torch.Tensor) -> torch.Tensor:
         """Make masks for self-attention.
@@ -136,7 +130,6 @@ class ConformerDecoder(torch.nn.Module):
             >>> self._source_mask(ilens)
             tensor([[[1, 1, 1, 1, 1],
                      [1, 1, 1, 0, 0]]], dtype=torch.uint8)
-
         """
         x_masks = make_non_pad_mask(ilens).to(next(self.parameters()).device)
         return x_masks.unsqueeze(-2)

--- a/src/utils/nets_utils.py
+++ b/src/utils/nets_utils.py
@@ -204,3 +204,18 @@ def make_non_pad_mask(lengths, xs=None, length_dim=-1):
                  [1, 1, 0, 0, 0, 0]]], dtype=torch.uint8)
     """
     return ~make_pad_mask(lengths, xs, length_dim)
+
+def get_activation(act):
+    """Return activation function."""
+    # Lazy load to avoid unused import
+    from ..models.components.conformer.swish import Swish
+
+    activation_funcs = {
+        "hardtanh": torch.nn.Hardtanh,
+        "tanh": torch.nn.Tanh,
+        "relu": torch.nn.ReLU,
+        "selu": torch.nn.SELU,
+        "swish": Swish,
+    }
+
+    return activation_funcs[act]()

--- a/src/utils/nets_utils.py
+++ b/src/utils/nets_utils.py
@@ -205,6 +205,7 @@ def make_non_pad_mask(lengths, xs=None, length_dim=-1):
     """
     return ~make_pad_mask(lengths, xs, length_dim)
 
+
 def get_activation(act):
     """Return activation function."""
     # Lazy load to avoid unused import

--- a/tests/models/components/conformer/test_attention.py
+++ b/tests/models/components/conformer/test_attention.py
@@ -1,0 +1,111 @@
+import torch
+from pytest import mark
+
+from src.models.components.conformer.attention import (
+    LegacyRelPositionMultiHeadedAttention,
+    RelPositionMultiHeadedAttention
+)
+from src.models.components.conformer.embedding import (
+    LegacyRelPositionalEncoding,
+    RelPositionalEncoding
+)
+
+@mark.parametrize(
+    "batch_size, n_head, n_feat, dropout_rate, feats_T",
+    [
+        (1,4,80,0.1,5),
+        (3,4,80,0.1,5),
+        (3,8,80,0.1,5),
+        (3,8,512,0.1,5),
+        (3,8,512,0,5),
+        (3,8,512,0,10)
+    ]
+)
+def test_legacy_rel_position_multi_headed_attention(
+    batch_size:int,
+    n_head:int,
+    n_feat:int,
+    dropout_rate:int,
+    feats_T:int
+):
+    assert n_feat % n_head == 0
+    # attentionインスタンス
+    legacy_rel_pos_attn = LegacyRelPositionMultiHeadedAttention(
+        n_head=n_head,
+        n_feat=n_feat,
+        dropout_rate=dropout_rate
+    )
+
+    # positional_encodingインスタンス
+    pos_enc = LegacyRelPositionalEncoding(
+        d_model=n_feat,
+        dropout_rate=dropout_rate
+    )
+
+    # ランダムtensor作成
+    x = torch.rand(batch_size,n_feat,feats_T)   #(B, C, T)
+    x = x.transpose(1,2)                        #(B, T, C)
+
+    # positional encoding
+    dropout_x, pos_emb = pos_enc(x)
+
+    assert dropout_x.size() == torch.Size([batch_size,feats_T,n_feat])
+    assert dropout_x.all() == (False if dropout_rate > 0 else True)
+    assert pos_emb.size() == torch.Size([1,feats_T,n_feat])
+
+    # self attentioin
+    q = k = v = dropout_x                       #(B, T, C)
+    mask = torch.tensor([[[1 for j in range(feats_T)]] for i in range(batch_size)])
+    y = legacy_rel_pos_attn(q,k,v,pos_emb,mask)
+
+    assert y.size() == torch.Size([batch_size,feats_T,n_feat])
+
+@mark.parametrize(
+    "batch_size, n_head, n_feat, dropout_rate, feats_T",
+    [
+        (1,4,80,0.1,5),
+        (3,4,80,0.1,5),
+        (3,8,80,0.1,5),
+        (3,8,512,0.1,5),
+        (3,8,512,0,5),
+        (3,8,512,0,10)
+    ]
+)
+def test_rel_position_multi_headed_attention(
+    batch_size:int,
+    n_head:int,
+    n_feat:int,
+    dropout_rate:int,
+    feats_T:int
+):
+    assert n_feat % n_head == 0
+    # attentionインスタンス
+    rel_pos_attn = RelPositionMultiHeadedAttention(
+        n_head=n_head,
+        n_feat=n_feat,
+        dropout_rate=dropout_rate
+    )
+
+    # positional_encodingインスタンス
+    pos_enc = RelPositionalEncoding(
+        d_model=n_feat,
+        dropout_rate=dropout_rate
+    )
+
+    # ランダムtensor作成
+    x = torch.rand(batch_size,n_feat,feats_T)   #(B, C, T)
+    x = x.transpose(1,2)                        #(B, T, C)
+
+    # positional encoding
+    dropout_x, pos_emb = pos_enc(x)
+
+    assert dropout_x.size() == torch.Size([batch_size,feats_T,n_feat])
+    assert dropout_x.all() == (False if dropout_rate > 0 else True)
+    assert pos_emb.size() == torch.Size([1,feats_T*2-1,n_feat])
+
+    # self attentioin
+    q = k = v = dropout_x                       #(B, T, C)
+    mask = torch.tensor([[[1 for j in range(feats_T)]] for i in range(batch_size)])
+    y = rel_pos_attn(q,k,v,pos_emb,mask)
+
+    assert y.size() == torch.Size([batch_size,feats_T,n_feat])

--- a/tests/models/components/conformer/test_attention.py
+++ b/tests/models/components/conformer/test_attention.py
@@ -3,109 +3,93 @@ from pytest import mark
 
 from src.models.components.conformer.attention import (
     LegacyRelPositionMultiHeadedAttention,
-    RelPositionMultiHeadedAttention
+    RelPositionMultiHeadedAttention,
 )
 from src.models.components.conformer.embedding import (
     LegacyRelPositionalEncoding,
-    RelPositionalEncoding
+    RelPositionalEncoding,
 )
+
 
 @mark.parametrize(
     "batch_size, n_head, n_feat, dropout_rate, feats_T",
     [
-        (1,4,80,0.1,5),
-        (3,4,80,0.1,5),
-        (3,8,80,0.1,5),
-        (3,8,512,0.1,5),
-        (3,8,512,0,5),
-        (3,8,512,0,10)
-    ]
+        (1, 4, 80, 0.1, 5),
+        (3, 4, 80, 0.1, 5),
+        (3, 8, 80, 0.1, 5),
+        (3, 8, 512, 0.1, 5),
+        (3, 8, 512, 0, 5),
+        (3, 8, 512, 0, 10),
+    ],
 )
 def test_legacy_rel_position_multi_headed_attention(
-    batch_size:int,
-    n_head:int,
-    n_feat:int,
-    dropout_rate:int,
-    feats_T:int
+    batch_size: int, n_head: int, n_feat: int, dropout_rate: int, feats_T: int
 ):
     assert n_feat % n_head == 0
     # attentionインスタンス
     legacy_rel_pos_attn = LegacyRelPositionMultiHeadedAttention(
-        n_head=n_head,
-        n_feat=n_feat,
-        dropout_rate=dropout_rate
+        n_head=n_head, n_feat=n_feat, dropout_rate=dropout_rate
     )
 
     # positional_encodingインスタンス
-    pos_enc = LegacyRelPositionalEncoding(
-        d_model=n_feat,
-        dropout_rate=dropout_rate
-    )
+    pos_enc = LegacyRelPositionalEncoding(d_model=n_feat, dropout_rate=dropout_rate)
 
     # ランダムtensor作成
-    x = torch.rand(batch_size,n_feat,feats_T)   #(B, C, T)
-    x = x.transpose(1,2)                        #(B, T, C)
+    x = torch.rand(batch_size, n_feat, feats_T)  # (B, C, T)
+    x = x.transpose(1, 2)  # (B, T, C)
 
     # positional encoding
     dropout_x, pos_emb = pos_enc(x)
 
-    assert dropout_x.size() == torch.Size([batch_size,feats_T,n_feat])
+    assert dropout_x.size() == torch.Size([batch_size, feats_T, n_feat])
     assert dropout_x.all() == (False if dropout_rate > 0 else True)
-    assert pos_emb.size() == torch.Size([1,feats_T,n_feat])
+    assert pos_emb.size() == torch.Size([1, feats_T, n_feat])
 
     # self attentioin
-    q = k = v = dropout_x                       #(B, T, C)
+    q = k = v = dropout_x  # (B, T, C)
     mask = torch.tensor([[[1 for j in range(feats_T)]] for i in range(batch_size)])
-    y = legacy_rel_pos_attn(q,k,v,pos_emb,mask)
+    y = legacy_rel_pos_attn(q, k, v, pos_emb, mask)
 
-    assert y.size() == torch.Size([batch_size,feats_T,n_feat])
+    assert y.size() == torch.Size([batch_size, feats_T, n_feat])
+
 
 @mark.parametrize(
     "batch_size, n_head, n_feat, dropout_rate, feats_T",
     [
-        (1,4,80,0.1,5),
-        (3,4,80,0.1,5),
-        (3,8,80,0.1,5),
-        (3,8,512,0.1,5),
-        (3,8,512,0,5),
-        (3,8,512,0,10)
-    ]
+        (1, 4, 80, 0.1, 5),
+        (3, 4, 80, 0.1, 5),
+        (3, 8, 80, 0.1, 5),
+        (3, 8, 512, 0.1, 5),
+        (3, 8, 512, 0, 5),
+        (3, 8, 512, 0, 10),
+    ],
 )
 def test_rel_position_multi_headed_attention(
-    batch_size:int,
-    n_head:int,
-    n_feat:int,
-    dropout_rate:int,
-    feats_T:int
+    batch_size: int, n_head: int, n_feat: int, dropout_rate: int, feats_T: int
 ):
     assert n_feat % n_head == 0
     # attentionインスタンス
     rel_pos_attn = RelPositionMultiHeadedAttention(
-        n_head=n_head,
-        n_feat=n_feat,
-        dropout_rate=dropout_rate
+        n_head=n_head, n_feat=n_feat, dropout_rate=dropout_rate
     )
 
     # positional_encodingインスタンス
-    pos_enc = RelPositionalEncoding(
-        d_model=n_feat,
-        dropout_rate=dropout_rate
-    )
+    pos_enc = RelPositionalEncoding(d_model=n_feat, dropout_rate=dropout_rate)
 
     # ランダムtensor作成
-    x = torch.rand(batch_size,n_feat,feats_T)   #(B, C, T)
-    x = x.transpose(1,2)                        #(B, T, C)
+    x = torch.rand(batch_size, n_feat, feats_T)  # (B, C, T)
+    x = x.transpose(1, 2)  # (B, T, C)
 
     # positional encoding
     dropout_x, pos_emb = pos_enc(x)
 
-    assert dropout_x.size() == torch.Size([batch_size,feats_T,n_feat])
+    assert dropout_x.size() == torch.Size([batch_size, feats_T, n_feat])
     assert dropout_x.all() == (False if dropout_rate > 0 else True)
-    assert pos_emb.size() == torch.Size([1,feats_T*2-1,n_feat])
+    assert pos_emb.size() == torch.Size([1, feats_T * 2 - 1, n_feat])
 
     # self attentioin
-    q = k = v = dropout_x                       #(B, T, C)
+    q = k = v = dropout_x  # (B, T, C)
     mask = torch.tensor([[[1 for j in range(feats_T)]] for i in range(batch_size)])
-    y = rel_pos_attn(q,k,v,pos_emb,mask)
+    y = rel_pos_attn(q, k, v, pos_emb, mask)
 
-    assert y.size() == torch.Size([batch_size,feats_T,n_feat])
+    assert y.size() == torch.Size([batch_size, feats_T, n_feat])

--- a/tests/models/components/conformer/test_convolution.py
+++ b/tests/models/components/conformer/test_convolution.py
@@ -1,0 +1,23 @@
+import torch
+from pytest import mark
+
+from src.models.components.conformer.convolution import ConvolutionModule
+
+@mark.parametrize(
+    "batch_size, channels, feats_T",
+    [
+        (1,80,5),
+        (3,80,10),
+        (5,513,15)
+    ]
+)
+def test_convolution(batch_size:int,channels:int,feats_T:int):
+
+    conv = ConvolutionModule(channels=channels,kernel_size=3)
+
+    x = torch.rand(batch_size,channels,feats_T)# (B, C, T)
+
+    x = x.transpose(1,2)        # (B, T, C)
+    y = conv(x).transpose(1,2)  # (B, C, T)
+
+    assert y.size() == torch.Size([batch_size,channels,feats_T])

--- a/tests/models/components/conformer/test_convolution.py
+++ b/tests/models/components/conformer/test_convolution.py
@@ -3,21 +3,15 @@ from pytest import mark
 
 from src.models.components.conformer.convolution import ConvolutionModule
 
-@mark.parametrize(
-    "batch_size, channels, feats_T",
-    [
-        (1,80,5),
-        (3,80,10),
-        (5,513,15)
-    ]
-)
-def test_convolution(batch_size:int,channels:int,feats_T:int):
 
-    conv = ConvolutionModule(channels=channels,kernel_size=3)
+@mark.parametrize("batch_size, channels, feats_T", [(1, 80, 5), (3, 80, 10), (5, 513, 15)])
+def test_convolution(batch_size: int, channels: int, feats_T: int):
 
-    x = torch.rand(batch_size,channels,feats_T)# (B, C, T)
+    conv = ConvolutionModule(channels=channels, kernel_size=3)
 
-    x = x.transpose(1,2)        # (B, T, C)
-    y = conv(x).transpose(1,2)  # (B, C, T)
+    x = torch.rand(batch_size, channels, feats_T)  # (B, C, T)
 
-    assert y.size() == torch.Size([batch_size,channels,feats_T])
+    x = x.transpose(1, 2)  # (B, T, C)
+    y = conv(x).transpose(1, 2)  # (B, C, T)
+
+    assert y.size() == torch.Size([batch_size, channels, feats_T])

--- a/tests/models/components/conformer/test_embedding.py
+++ b/tests/models/components/conformer/test_embedding.py
@@ -1,0 +1,161 @@
+import pytest
+import torch
+
+from src.models.components.conformer.embedding import (
+    LearnableFourierPosEnc,
+    PositionalEncoding,
+    ScaledPositionalEncoding,
+)
+
+
+@pytest.mark.parametrize(
+    "dtype, device",
+    [(dt, dv) for dt in ("float32", "float64") for dv in ("cpu", "cuda")],
+)
+def test_pe_extendable(dtype, device):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("no cuda device is available")
+    dtype = getattr(torch, dtype)
+    dim = 2
+    pe = PositionalEncoding(dim, 0.0, 3).to(dtype=dtype, device=device)
+    x = torch.rand(2, 3, dim, dtype=dtype, device=device)
+    y = pe(x)
+    init_cache = pe.pe
+
+    # test not extended from init
+    x = torch.rand(2, 3, dim, dtype=dtype, device=device)
+    y = pe(x)
+    assert pe.pe is init_cache
+
+    x = torch.rand(2, 5, dim, dtype=dtype, device=device)
+    y = pe(x)
+
+    sd = pe.state_dict()
+    assert len(sd) == 0, "PositionalEncoding should save nothing"
+    pe2 = PositionalEncoding(dim, 0.0, 3).to(dtype=dtype, device=device)
+    pe2.load_state_dict(sd)
+    y2 = pe2(x)
+    assert torch.allclose(y, y2)
+
+
+@pytest.mark.parametrize(
+    "dtype, device, apply_scaling, hidden_dim",
+    [
+        (dt, dv, scal, hd)
+        for dt in ("float32", "float64")
+        for dv in ("cpu", "cuda")
+        for scal in [True, False]
+        for hd in [None, 12]
+    ],
+)
+def test_learnedFourierPe_extendable(dtype, device, apply_scaling, hidden_dim):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("no cuda device is available")
+    dtype = getattr(torch, dtype)
+    dim = 2
+    pe = LearnableFourierPosEnc(
+        dim, apply_scaling=apply_scaling, hidden_dim=hidden_dim
+    ).to(dtype=dtype, device=device)
+    x = torch.rand(2, 3, dim, dtype=dtype, device=device)
+    pe(x)
+
+    x = torch.rand(2, 5, dim, dtype=dtype, device=device)
+    pe(x)
+
+
+@pytest.mark.parametrize(
+    "dtype, device",
+    [(dt, dv) for dt in ("float32", "float64") for dv in ("cpu", "cuda")],
+)
+def test_scaled_pe_extendable(dtype, device):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("no cuda device is available")
+    dtype = getattr(torch, dtype)
+    dim = 2
+    pe = ScaledPositionalEncoding(dim, 0.0, 3).to(dtype=dtype, device=device)
+    x = torch.rand(2, 3, dim, dtype=dtype, device=device)
+    y = pe(x)
+    init_cache = pe.pe
+
+    # test not extended from init
+    x = torch.rand(2, 3, dim, dtype=dtype, device=device)
+    y = pe(x)
+    assert pe.pe is init_cache
+
+    x = torch.rand(2, 5, dim, dtype=dtype, device=device)
+    y = pe(x)
+
+    sd = pe.state_dict()
+    assert sd == {"alpha": pe.alpha}, "ScaledPositionalEncoding should save only alpha"
+    pe2 = ScaledPositionalEncoding(dim, 0.0, 3).to(dtype=dtype, device=device)
+    pe2.load_state_dict(sd)
+    y2 = pe2(x)
+    assert torch.allclose(y, y2)
+
+
+class LegacyPositionalEncoding(torch.nn.Module):
+    """Positional encoding module until v.0.5.2."""
+
+    def __init__(self, d_model, dropout_rate, max_len=5000):
+        import math
+
+        super().__init__()
+        self.dropout = torch.nn.Dropout(p=dropout_rate)
+        # Compute the positional encodings once in log space.
+        pe = torch.zeros(max_len, d_model)
+        position = torch.arange(0, max_len, dtype=torch.float32).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, d_model, 2, dtype=torch.float32)
+            * -(math.log(10000.0) / d_model)
+        )
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0)
+        self.max_len = max_len
+        self.xscale = math.sqrt(d_model)
+        self.register_buffer("pe", pe)
+
+    def forward(self, x):
+        x = x * self.xscale + self.pe[:, : x.size(1)]
+        return self.dropout(x)
+
+
+class LegacyScaledPositionalEncoding(LegacyPositionalEncoding):
+    """Positional encoding module until v.0.5.2."""
+
+    def __init__(self, d_model, dropout_rate, max_len=5000):
+        super().__init__(d_model=d_model, dropout_rate=dropout_rate, max_len=max_len)
+        self.alpha = torch.nn.Parameter(torch.tensor(1.0))
+
+    def forward(self, x):
+        x = x + self.alpha * self.pe[:, : x.size(1)]
+        return self.dropout(x)
+
+
+def test_compatibility():
+    """Regression test for #1121"""
+    x = torch.rand(2, 3, 4)
+
+    legacy_net = torch.nn.Sequential(
+        LegacyPositionalEncoding(4, 0.0), torch.nn.Linear(4, 2)
+    )
+
+    latest_net = torch.nn.Sequential(PositionalEncoding(4, 0.0), torch.nn.Linear(4, 2))
+
+    latest_net.load_state_dict(legacy_net.state_dict())
+    legacy = legacy_net(x)
+    latest = latest_net(x)
+    assert torch.allclose(legacy, latest)
+
+    legacy_net = torch.nn.Sequential(
+        LegacyScaledPositionalEncoding(4, 0.0), torch.nn.Linear(4, 2)
+    )
+
+    latest_net = torch.nn.Sequential(
+        ScaledPositionalEncoding(4, 0.0), torch.nn.Linear(4, 2)
+    )
+
+    latest_net.load_state_dict(legacy_net.state_dict())
+    legacy = legacy_net(x)
+    latest = latest_net(x)
+    assert torch.allclose(legacy, latest)

--- a/tests/models/components/conformer/test_embedding.py
+++ b/tests/models/components/conformer/test_embedding.py
@@ -53,9 +53,9 @@ def test_learnedFourierPe_extendable(dtype, device, apply_scaling, hidden_dim):
         pytest.skip("no cuda device is available")
     dtype = getattr(torch, dtype)
     dim = 2
-    pe = LearnableFourierPosEnc(
-        dim, apply_scaling=apply_scaling, hidden_dim=hidden_dim
-    ).to(dtype=dtype, device=device)
+    pe = LearnableFourierPosEnc(dim, apply_scaling=apply_scaling, hidden_dim=hidden_dim).to(
+        dtype=dtype, device=device
+    )
     x = torch.rand(2, 3, dim, dtype=dtype, device=device)
     pe(x)
 
@@ -105,8 +105,7 @@ class LegacyPositionalEncoding(torch.nn.Module):
         pe = torch.zeros(max_len, d_model)
         position = torch.arange(0, max_len, dtype=torch.float32).unsqueeze(1)
         div_term = torch.exp(
-            torch.arange(0, d_model, 2, dtype=torch.float32)
-            * -(math.log(10000.0) / d_model)
+            torch.arange(0, d_model, 2, dtype=torch.float32) * -(math.log(10000.0) / d_model)
         )
         pe[:, 0::2] = torch.sin(position * div_term)
         pe[:, 1::2] = torch.cos(position * div_term)
@@ -133,12 +132,10 @@ class LegacyScaledPositionalEncoding(LegacyPositionalEncoding):
 
 
 def test_compatibility():
-    """Regression test for #1121"""
+    """Regression test for #1121."""
     x = torch.rand(2, 3, 4)
 
-    legacy_net = torch.nn.Sequential(
-        LegacyPositionalEncoding(4, 0.0), torch.nn.Linear(4, 2)
-    )
+    legacy_net = torch.nn.Sequential(LegacyPositionalEncoding(4, 0.0), torch.nn.Linear(4, 2))
 
     latest_net = torch.nn.Sequential(PositionalEncoding(4, 0.0), torch.nn.Linear(4, 2))
 
@@ -147,13 +144,9 @@ def test_compatibility():
     latest = latest_net(x)
     assert torch.allclose(legacy, latest)
 
-    legacy_net = torch.nn.Sequential(
-        LegacyScaledPositionalEncoding(4, 0.0), torch.nn.Linear(4, 2)
-    )
+    legacy_net = torch.nn.Sequential(LegacyScaledPositionalEncoding(4, 0.0), torch.nn.Linear(4, 2))
 
-    latest_net = torch.nn.Sequential(
-        ScaledPositionalEncoding(4, 0.0), torch.nn.Linear(4, 2)
-    )
+    latest_net = torch.nn.Sequential(ScaledPositionalEncoding(4, 0.0), torch.nn.Linear(4, 2))
 
     latest_net.load_state_dict(legacy_net.state_dict())
     legacy = legacy_net(x)

--- a/tests/models/components/conformer/test_encoder.py
+++ b/tests/models/components/conformer/test_encoder.py
@@ -1,0 +1,42 @@
+from pytest import mark
+import torch
+
+from src.models.components.conformer.encoder import Encoder
+
+@mark.parametrize(
+    """
+    batch_size, 
+    attention_dim, 
+    feats_T,
+    legacy
+    """,
+    [
+        (1,192,5,True),
+        (3,384,15,False),
+
+    ]
+)
+def test_encoder(
+    batch_size,
+    attention_dim,
+    feats_T,
+    legacy,
+):
+    # encoderインスタンス
+    if legacy:
+        pos_enc_layer_type="legacy_rel_pos"
+        selfattention_layer_type="legacy_rel_selfattn"
+    else:
+        pos_enc_layer_type="rel_pos"
+        selfattention_layer_type="rel_selfattn"
+    encoder = Encoder(
+        idim=feats_T,
+        attention_dim=attention_dim,
+        pos_enc_layer_type=pos_enc_layer_type,
+        selfattention_layer_type=selfattention_layer_type
+    )
+
+    # ランダムtensor作成
+    z = torch.rand(batch_size,feats_T,attention_dim)
+
+    y = encoder(z,None)

--- a/tests/models/components/conformer/test_encoder.py
+++ b/tests/models/components/conformer/test_encoder.py
@@ -1,20 +1,20 @@
-from pytest import mark
 import torch
+from pytest import mark
 
 from src.models.components.conformer.encoder import Encoder
 
+
 @mark.parametrize(
     """
-    batch_size, 
-    attention_dim, 
+    batch_size,
+    attention_dim,
     feats_T,
     legacy
     """,
     [
-        (1,192,5,True),
-        (3,384,15,False),
-
-    ]
+        (1, 192, 5, True),
+        (3, 384, 15, False),
+    ],
 )
 def test_encoder(
     batch_size,
@@ -24,19 +24,19 @@ def test_encoder(
 ):
     # encoderインスタンス
     if legacy:
-        pos_enc_layer_type="legacy_rel_pos"
-        selfattention_layer_type="legacy_rel_selfattn"
+        pos_enc_layer_type = "legacy_rel_pos"
+        selfattention_layer_type = "legacy_rel_selfattn"
     else:
-        pos_enc_layer_type="rel_pos"
-        selfattention_layer_type="rel_selfattn"
+        pos_enc_layer_type = "rel_pos"
+        selfattention_layer_type = "rel_selfattn"
     encoder = Encoder(
         idim=feats_T,
         attention_dim=attention_dim,
         pos_enc_layer_type=pos_enc_layer_type,
-        selfattention_layer_type=selfattention_layer_type
+        selfattention_layer_type=selfattention_layer_type,
     )
 
     # ランダムtensor作成
-    z = torch.rand(batch_size,feats_T,attention_dim)
+    z = torch.rand(batch_size, feats_T, attention_dim)
 
-    y = encoder(z,None)
+    y = encoder(z, None)

--- a/tests/models/components/conformer/test_encoder_layer.py
+++ b/tests/models/components/conformer/test_encoder_layer.py
@@ -1,16 +1,17 @@
-from pytest import mark
 import torch
+from pytest import mark
 
 from src.models.components.conformer.attention import RelPositionMultiHeadedAttention
-from src.models.components.conformer.multi_layer_conv import MultiLayeredConv1d
-from src.models.components.conformer.convolution import ConvolutionModule 
-from src.models.components.conformer.encoder_layer import EncoderLayer
+from src.models.components.conformer.convolution import ConvolutionModule
 from src.models.components.conformer.embedding import RelPositionalEncoding
+from src.models.components.conformer.encoder_layer import EncoderLayer
+from src.models.components.conformer.multi_layer_conv import MultiLayeredConv1d
+
 
 @mark.parametrize(
     """
     batch_size,
-    attention_dim, 
+    attention_dim,
     macaron_style,
     use_cnn_module,
     normalize_before,
@@ -18,14 +19,13 @@ from src.models.components.conformer.embedding import RelPositionalEncoding
     stochastic_depth_rate,
     """,
     [
-        (1,192,True,True,True,True,0.0),
-        (3,384,False,False,False,False,0.1),
-
-    ]
+        (1, 192, True, True, True, True, 0.0),
+        (3, 384, False, False, False, False, 0.1),
+    ],
 )
 def test_multi_layered_conv1d(
     batch_size,
-    attention_dim, 
+    attention_dim,
     macaron_style,
     use_cnn_module,
     normalize_before,
@@ -35,29 +35,21 @@ def test_multi_layered_conv1d(
     feats_T = 5
 
     # positional_encodingインスタンス
-    pos_enc = RelPositionalEncoding(
-        attention_dim,
-        0.1
-    )
+    pos_enc = RelPositionalEncoding(attention_dim, 0.1)
 
     # self_attention_layerインスタンス
     selfattn_layer = RelPositionMultiHeadedAttention(
-        n_head=4,
-        n_feat=attention_dim,
-        dropout_rate=0.1
+        n_head=4, n_feat=attention_dim, dropout_rate=0.1
     )
 
     # positionwise_layerインスタンス
     positionwise_layer = MultiLayeredConv1d(
-        in_chans=attention_dim,
-        hidden_chans=attention_dim,
-        kernel_size=3,
-        dropout_rate=0.1
+        in_chans=attention_dim, hidden_chans=attention_dim, kernel_size=3, dropout_rate=0.1
     )
 
     # convolution_layerインスタンス
-    convolution_layer = ConvolutionModule(channels=attention_dim,kernel_size=3)
-    
+    convolution_layer = ConvolutionModule(channels=attention_dim, kernel_size=3)
+
     # encoder_layerインスタンス
     encoder_layer = EncoderLayer(
         attention_dim,
@@ -72,16 +64,15 @@ def test_multi_layered_conv1d(
     )
 
     # ランダムtensor作成
-    mean = torch.rand(batch_size,attention_dim,feats_T)
-    logs = torch.rand(batch_size,attention_dim,feats_T)
-    x_mask = torch.tensor([[[1]*feats_T] for i in range(batch_size)])
+    mean = torch.rand(batch_size, attention_dim, feats_T)
+    logs = torch.rand(batch_size, attention_dim, feats_T)
+    x_mask = torch.tensor([[[1] * feats_T] for i in range(batch_size)])
     z = (mean + torch.randn_like(mean) * torch.exp(logs)) * x_mask  # reparametarize
-    z = z.transpose(1,2)
+    z = z.transpose(1, 2)
 
-    zs = pos_enc(z)                                 # (z, pos_emb)
+    zs = pos_enc(z)  # (z, pos_emb)
 
-    z_and_pos_emb,masks = encoder_layer(zs,x_mask)  # (z, pos_emb), masks
+    z_and_pos_emb, masks = encoder_layer(zs, x_mask)  # (z, pos_emb), masks
     z_hat = z_and_pos_emb[0]
 
-    assert z_hat.size() == torch.Size([batch_size,feats_T,attention_dim])
-
+    assert z_hat.size() == torch.Size([batch_size, feats_T, attention_dim])

--- a/tests/models/components/conformer/test_encoder_layer.py
+++ b/tests/models/components/conformer/test_encoder_layer.py
@@ -1,0 +1,87 @@
+from pytest import mark
+import torch
+
+from src.models.components.conformer.attention import RelPositionMultiHeadedAttention
+from src.models.components.conformer.multi_layer_conv import MultiLayeredConv1d
+from src.models.components.conformer.convolution import ConvolutionModule 
+from src.models.components.conformer.encoder_layer import EncoderLayer
+from src.models.components.conformer.embedding import RelPositionalEncoding
+
+@mark.parametrize(
+    """
+    batch_size,
+    attention_dim, 
+    macaron_style,
+    use_cnn_module,
+    normalize_before,
+    concat_after,
+    stochastic_depth_rate,
+    """,
+    [
+        (1,192,True,True,True,True,0.0),
+        (3,384,False,False,False,False,0.1),
+
+    ]
+)
+def test_multi_layered_conv1d(
+    batch_size,
+    attention_dim, 
+    macaron_style,
+    use_cnn_module,
+    normalize_before,
+    concat_after,
+    stochastic_depth_rate,
+):
+    feats_T = 5
+
+    # positional_encodingインスタンス
+    pos_enc = RelPositionalEncoding(
+        attention_dim,
+        0.1
+    )
+
+    # self_attention_layerインスタンス
+    selfattn_layer = RelPositionMultiHeadedAttention(
+        n_head=4,
+        n_feat=attention_dim,
+        dropout_rate=0.1
+    )
+
+    # positionwise_layerインスタンス
+    positionwise_layer = MultiLayeredConv1d(
+        in_chans=attention_dim,
+        hidden_chans=attention_dim,
+        kernel_size=3,
+        dropout_rate=0.1
+    )
+
+    # convolution_layerインスタンス
+    convolution_layer = ConvolutionModule(channels=attention_dim,kernel_size=3)
+    
+    # encoder_layerインスタンス
+    encoder_layer = EncoderLayer(
+        attention_dim,
+        selfattn_layer,
+        positionwise_layer,
+        positionwise_layer if macaron_style else None,
+        convolution_layer if use_cnn_module else None,
+        dropout_rate=0.1,
+        normalize_before=normalize_before,
+        concat_after=concat_after,
+        stochastic_depth_rate=stochastic_depth_rate,
+    )
+
+    # ランダムtensor作成
+    mean = torch.rand(batch_size,attention_dim,feats_T)
+    logs = torch.rand(batch_size,attention_dim,feats_T)
+    x_mask = torch.tensor([[[1]*feats_T] for i in range(batch_size)])
+    z = (mean + torch.randn_like(mean) * torch.exp(logs)) * x_mask  # reparametarize
+    z = z.transpose(1,2)
+
+    zs = pos_enc(z)                                 # (z, pos_emb)
+
+    z_and_pos_emb,masks = encoder_layer(zs,x_mask)  # (z, pos_emb), masks
+    z_hat = z_and_pos_emb[0]
+
+    assert z_hat.size() == torch.Size([batch_size,feats_T,attention_dim])
+

--- a/tests/models/components/conformer/test_layer_norm.py
+++ b/tests/models/components/conformer/test_layer_norm.py
@@ -2,14 +2,13 @@ import torch
 
 from src.models.components.conformer.layer_norm import LayerNorm
 
+
 def test_layer_norm():
-    """
-    「分散が0＝すべての値が等しい」なので軸方向で値が等しいかを判定できる
-     誤差で完全に0にならないっぽいので1e-12未満で判定
-    """
+    """「分散が0＝すべての値が等しい」なので軸方向で値が等しいかを判定できる 誤差で完全に0にならないっぽいので1e-12未満で判定."""
     x = torch.tensor(
-        [[[4*i+j*2+k for k in range(2)] for j in range(4)] for i in range(4)],
-        dtype=torch.float32)
+        [[[4 * i + j * 2 + k for k in range(2)] for j in range(4)] for i in range(4)],
+        dtype=torch.float32,
+    )
     # >>> x
     # tensor([[[ 0.,  1.],
     #          [ 2.,  3.],
@@ -30,19 +29,18 @@ def test_layer_norm():
     #          [14., 15.],
     #          [16., 17.],
     #          [18., 19.]]])
-    
+
     # default normalize (dim=-1)
     layer_norm = LayerNorm(nout=2)
     assert (layer_norm(x).var(dim=0) < 1e-12).all()
     assert (layer_norm(x).var(dim=1) < 1e-12).all()
 
     # default normalize (dim=0)
-    layer_norm = LayerNorm(nout=4,dim=1)
+    layer_norm = LayerNorm(nout=4, dim=1)
     assert (layer_norm(x).var(dim=0) < 1e-12).all()
     assert (layer_norm(x).var(dim=2) < 1e-12).all()
-    
+
     # default normalize (dim=1)
-    layer_norm = LayerNorm(nout=4,dim=0)
+    layer_norm = LayerNorm(nout=4, dim=0)
     assert (layer_norm(x).var(dim=2) < 1e-12).all()
     assert (layer_norm(x).var(dim=1) < 1e-12).all()
-    

--- a/tests/models/components/conformer/test_layer_norm.py
+++ b/tests/models/components/conformer/test_layer_norm.py
@@ -1,0 +1,48 @@
+import torch
+
+from src.models.components.conformer.layer_norm import LayerNorm
+
+def test_layer_norm():
+    """
+    「分散が0＝すべての値が等しい」なので軸方向で値が等しいかを判定できる
+     誤差で完全に0にならないっぽいので1e-12未満で判定
+    """
+    x = torch.tensor(
+        [[[4*i+j*2+k for k in range(2)] for j in range(4)] for i in range(4)],
+        dtype=torch.float32)
+    # >>> x
+    # tensor([[[ 0.,  1.],
+    #          [ 2.,  3.],
+    #          [ 4.,  5.],
+    #          [ 6.,  7.]],
+
+    #         [[ 4.,  5.],
+    #          [ 6.,  7.],
+    #          [ 8.,  9.],
+    #          [10., 11.]],
+
+    #         [[ 8.,  9.],
+    #          [10., 11.],
+    #          [12., 13.],
+    #          [14., 15.]],
+
+    #         [[12., 13.],
+    #          [14., 15.],
+    #          [16., 17.],
+    #          [18., 19.]]])
+    
+    # default normalize (dim=-1)
+    layer_norm = LayerNorm(nout=2)
+    assert (layer_norm(x).var(dim=0) < 1e-12).all()
+    assert (layer_norm(x).var(dim=1) < 1e-12).all()
+
+    # default normalize (dim=0)
+    layer_norm = LayerNorm(nout=4,dim=1)
+    assert (layer_norm(x).var(dim=0) < 1e-12).all()
+    assert (layer_norm(x).var(dim=2) < 1e-12).all()
+    
+    # default normalize (dim=1)
+    layer_norm = LayerNorm(nout=4,dim=0)
+    assert (layer_norm(x).var(dim=2) < 1e-12).all()
+    assert (layer_norm(x).var(dim=1) < 1e-12).all()
+    

--- a/tests/models/components/conformer/test_multi_layer_conv.py
+++ b/tests/models/components/conformer/test_multi_layer_conv.py
@@ -1,0 +1,42 @@
+from pytest import mark
+import torch
+
+from src.models.components.conformer.multi_layer_conv import MultiLayeredConv1d
+
+@mark.parametrize(
+    """
+    batch_size, 
+    in_chans, 
+    hidden_chans, 
+    kernel_size, 
+    feats_T
+    """,
+    [
+        (1,80,192,3,5),
+        (3,513,192,5,15),
+    ]
+)
+def test_multi_layered_conv1d(
+    batch_size,
+    in_chans, 
+    hidden_chans,
+    kernel_size,
+    feats_T,
+):
+
+    # multi_layer_convインスタンス
+    multi_layer_conv = MultiLayeredConv1d(
+        in_chans=in_chans,
+        hidden_chans=hidden_chans,
+        kernel_size=kernel_size,
+        dropout_rate=0.1
+    )
+
+    # ランダムtensor作成
+    x = torch.rand(batch_size,in_chans,feats_T)
+    x = x.transpose(1,2)            # (B, T, C)
+
+    y = multi_layer_conv(x)
+
+    assert y.size() == torch.Size([batch_size,feats_T,in_chans])
+

--- a/tests/models/components/conformer/test_multi_layer_conv.py
+++ b/tests/models/components/conformer/test_multi_layer_conv.py
@@ -1,24 +1,25 @@
-from pytest import mark
 import torch
+from pytest import mark
 
 from src.models.components.conformer.multi_layer_conv import MultiLayeredConv1d
 
+
 @mark.parametrize(
     """
-    batch_size, 
-    in_chans, 
-    hidden_chans, 
-    kernel_size, 
+    batch_size,
+    in_chans,
+    hidden_chans,
+    kernel_size,
     feats_T
     """,
     [
-        (1,80,192,3,5),
-        (3,513,192,5,15),
-    ]
+        (1, 80, 192, 3, 5),
+        (3, 513, 192, 5, 15),
+    ],
 )
 def test_multi_layered_conv1d(
     batch_size,
-    in_chans, 
+    in_chans,
     hidden_chans,
     kernel_size,
     feats_T,
@@ -26,17 +27,13 @@ def test_multi_layered_conv1d(
 
     # multi_layer_convインスタンス
     multi_layer_conv = MultiLayeredConv1d(
-        in_chans=in_chans,
-        hidden_chans=hidden_chans,
-        kernel_size=kernel_size,
-        dropout_rate=0.1
+        in_chans=in_chans, hidden_chans=hidden_chans, kernel_size=kernel_size, dropout_rate=0.1
     )
 
     # ランダムtensor作成
-    x = torch.rand(batch_size,in_chans,feats_T)
-    x = x.transpose(1,2)            # (B, T, C)
+    x = torch.rand(batch_size, in_chans, feats_T)
+    x = x.transpose(1, 2)  # (B, T, C)
 
     y = multi_layer_conv(x)
 
-    assert y.size() == torch.Size([batch_size,feats_T,in_chans])
-
+    assert y.size() == torch.Size([batch_size, feats_T, in_chans])

--- a/tests/models/components/conformer/test_postnet.py
+++ b/tests/models/components/conformer/test_postnet.py
@@ -1,0 +1,48 @@
+from pytest import mark
+import torch
+
+from src.models.components.conformer.postnet import Postnet
+
+@mark.parametrize(
+    """
+    batch_size, 
+    n_layers, 
+    n_chans, 
+    n_filts, 
+    feats_T, 
+    use_batch_norm
+    """,
+    [
+        (1,1,80,3,5,True),
+        (3,2,513,5,15,False),
+
+    ]
+)
+def test_postnet(
+    batch_size:int,
+    n_layers:int,
+    n_chans:int,
+    n_filts:int,
+    feats_T:int,
+    use_batch_norm:bool
+):
+    # Postnetインスタンス
+    idim = 1        # idimは内部で参照されない引数なので適当に1を代入
+    odim=feats_T    # odimが実質idimの役割
+
+    postnet = Postnet(
+        idim=idim,
+        odim=odim,
+        n_layers=n_layers,
+        n_chans=n_chans,
+        n_filts=n_filts,
+        dropout_rate=0.5,
+        use_batch_norm=use_batch_norm,
+    )
+
+    #ランダムテンソル作成
+    x = torch.rand(batch_size,n_chans,feats_T)
+    x = x.transpose(1,2)            # (B, T, C)
+    y = postnet(x)
+
+    assert y.size() == torch.Size([batch_size,feats_T,n_chans])

--- a/tests/models/components/conformer/test_postnet.py
+++ b/tests/models/components/conformer/test_postnet.py
@@ -1,34 +1,29 @@
-from pytest import mark
 import torch
+from pytest import mark
 
 from src.models.components.conformer.postnet import Postnet
 
+
 @mark.parametrize(
     """
-    batch_size, 
-    n_layers, 
-    n_chans, 
-    n_filts, 
-    feats_T, 
+    batch_size,
+    n_layers,
+    n_chans,
+    n_filts,
+    feats_T,
     use_batch_norm
     """,
     [
-        (1,1,80,3,5,True),
-        (3,2,513,5,15,False),
-
-    ]
+        (1, 1, 80, 3, 5, True),
+        (3, 2, 513, 5, 15, False),
+    ],
 )
 def test_postnet(
-    batch_size:int,
-    n_layers:int,
-    n_chans:int,
-    n_filts:int,
-    feats_T:int,
-    use_batch_norm:bool
+    batch_size: int, n_layers: int, n_chans: int, n_filts: int, feats_T: int, use_batch_norm: bool
 ):
     # Postnetインスタンス
-    idim = 1        # idimは内部で参照されない引数なので適当に1を代入
-    odim=feats_T    # odimが実質idimの役割
+    idim = 1  # idimは内部で参照されない引数なので適当に1を代入
+    odim = feats_T  # odimが実質idimの役割
 
     postnet = Postnet(
         idim=idim,
@@ -40,9 +35,9 @@ def test_postnet(
         use_batch_norm=use_batch_norm,
     )
 
-    #ランダムテンソル作成
-    x = torch.rand(batch_size,n_chans,feats_T)
-    x = x.transpose(1,2)            # (B, T, C)
+    # ランダムテンソル作成
+    x = torch.rand(batch_size, n_chans, feats_T)
+    x = x.transpose(1, 2)  # (B, T, C)
     y = postnet(x)
 
-    assert y.size() == torch.Size([batch_size,feats_T,n_chans])
+    assert y.size() == torch.Size([batch_size, feats_T, n_chans])

--- a/tests/models/components/conformer/test_repeat.py
+++ b/tests/models/components/conformer/test_repeat.py
@@ -3,8 +3,9 @@ from pytest import mark
 
 from src.models.components.conformer.repeat import repeat
 
-@mark.parametrize("N_repeat", [1,3,5])
-def test_repeat(N_repeat:int):
+
+@mark.parametrize("N_repeat", [1, 3, 5])
+def test_repeat(N_repeat: int):
     """
     Example:
     N_repeat=3でLinearを繰り返す場合
@@ -16,5 +17,5 @@ def test_repeat(N_repeat:int):
       (2): Linear(in_features=3, out_features=4, bias=True)
     )
     """
-    repeated_layer = repeat(N_repeat,lambda n:torch.nn.Linear(n+1,n+2))
+    repeated_layer = repeat(N_repeat, lambda n: torch.nn.Linear(n + 1, n + 2))
     assert len(repeated_layer) == N_repeat

--- a/tests/models/components/conformer/test_repeat.py
+++ b/tests/models/components/conformer/test_repeat.py
@@ -1,0 +1,20 @@
+import torch
+from pytest import mark
+
+from src.models.components.conformer.repeat import repeat
+
+@mark.parametrize("N_repeat", [1,3,5])
+def test_repeat(N_repeat:int):
+    """
+    Example:
+    N_repeat=3でLinearを繰り返す場合
+
+    >>> repeat(3,lambda n:torch.nn.Linear(n+1,n+2))
+    MultiSequential(
+      (0): Linear(in_features=1, out_features=2, bias=True)
+      (1): Linear(in_features=2, out_features=3, bias=True)
+      (2): Linear(in_features=3, out_features=4, bias=True)
+    )
+    """
+    repeated_layer = repeat(N_repeat,lambda n:torch.nn.Linear(n+1,n+2))
+    assert len(repeated_layer) == N_repeat

--- a/tests/models/components/conformer/test_swish.py
+++ b/tests/models/components/conformer/test_swish.py
@@ -1,21 +1,21 @@
-import torch
-import matplotlib.pyplot as plt
 from pathlib import Path
+
+import matplotlib.pyplot as plt
+import torch
 
 from src.models.components.conformer.swish import Swish
 
+
 def test_swish():
-    """
-    グラフにプロットして確認する
-    """
+    """グラフにプロットして確認する."""
     # plot
-    x = torch.tensor([x*0.1 for x in range(-100,100)],dtype=torch.float32)
+    x = torch.tensor([x * 0.1 for x in range(-100, 100)], dtype=torch.float32)
     swish = Swish()
     y = swish(x)
-    plt.plot(x,y)
+    plt.plot(x, y)
 
     # save figure
     dirpath = Path(__file__).parent / "test_plot"
-    dirpath.mkdir(exist_ok=True,parents=True)
+    dirpath.mkdir(exist_ok=True, parents=True)
     filepath = dirpath / "swish.png"
     plt.savefig(filepath)

--- a/tests/models/components/conformer/test_swish.py
+++ b/tests/models/components/conformer/test_swish.py
@@ -1,0 +1,21 @@
+import torch
+import matplotlib.pyplot as plt
+from pathlib import Path
+
+from src.models.components.conformer.swish import Swish
+
+def test_swish():
+    """
+    グラフにプロットして確認する
+    """
+    # plot
+    x = torch.tensor([x*0.1 for x in range(-100,100)],dtype=torch.float32)
+    swish = Swish()
+    y = swish(x)
+    plt.plot(x,y)
+
+    # save figure
+    dirpath = Path(__file__).parent / "test_plot"
+    dirpath.mkdir(exist_ok=True,parents=True)
+    filepath = dirpath / "swish.png"
+    plt.savefig(filepath)

--- a/tests/models/components/test_conformer_decoder_fastspeech2.py
+++ b/tests/models/components/test_conformer_decoder_fastspeech2.py
@@ -1,7 +1,8 @@
-from pytest import mark
 import torch
+from pytest import mark
 
 from src.models.components.conformer_decoder_fastspeech2 import ConformerDecoder
+
 
 @mark.parametrize(
     """
@@ -11,27 +12,17 @@ from src.models.components.conformer_decoder_fastspeech2 import ConformerDecoder
     feats_T
     """,
     [
-        (1,192,80,5),
-        (3,384,513,15),
-
-    ]
+        (1, 192, 80, 5),
+        (3, 384, 513, 15),
+    ],
 )
-def test_decoder(
-    batch_size,
-    attention_dim,
-    n_channels,
-    feats_T
-):
+def test_decoder(batch_size, attention_dim, n_channels, feats_T):
     # conformer_decoderインスタンス
-    decoder = ConformerDecoder(
-        idim=feats_T,
-        odim=n_channels,
-        adim=attention_dim
-        )
+    decoder = ConformerDecoder(idim=feats_T, odim=n_channels, adim=attention_dim)
 
     # ランダムtensor作成
-    z = torch.rand(batch_size,attention_dim,feats_T)
+    z = torch.rand(batch_size, attention_dim, feats_T)
 
     y = decoder(z)
 
-    assert y.size() == torch.Size([batch_size,n_channels,feats_T])
+    assert y.size() == torch.Size([batch_size, n_channels, feats_T])

--- a/tests/models/components/test_conformer_decoder_fastspeech2.py
+++ b/tests/models/components/test_conformer_decoder_fastspeech2.py
@@ -1,0 +1,37 @@
+from pytest import mark
+import torch
+
+from src.models.components.conformer_decoder_fastspeech2 import ConformerDecoder
+
+@mark.parametrize(
+    """
+    batch_size,
+    attention_dim,
+    n_channels,
+    feats_T
+    """,
+    [
+        (1,192,80,5),
+        (3,384,513,15),
+
+    ]
+)
+def test_decoder(
+    batch_size,
+    attention_dim,
+    n_channels,
+    feats_T
+):
+    # conformer_decoderインスタンス
+    decoder = ConformerDecoder(
+        idim=feats_T,
+        odim=n_channels,
+        adim=attention_dim
+        )
+
+    # ランダムtensor作成
+    z = torch.rand(batch_size,attention_dim,feats_T)
+
+    y = decoder(z)
+
+    assert y.size() == torch.Size([batch_size,n_channels,feats_T])


### PR DESCRIPTION
## 概要
Decoder(conformer)をespnetから移植

## 変更内容
issue番号#15
「Decoder(conformer)の実装」
espnetのfastspeech2実装からdecoderの部分で使われているモジュールを移植
- `src/models/components/conformer` ディレクトリ内にモジュールを追加
- `src/models/components/conformer_decoder_fastspeech2.py` ファイルを追加(仮実装)
- `tests/models/components/conformer`  に各種テストコードを追加
- `tests/models/components/test_conformer_decoder_fastspeech2.py` を追加
- `src/utils/nets_utils.py` に活性化関数を取得する関数「`get_activation()`」を追加

## 影響範囲
- `src/models/components/conformer` 内
- `tests/models/components/conformer` 内
- `conformer_decoder_fastspeech2.py`
- `test_conformer_decoder_fastspeech2.py`
のみに影響

`nets_utils.py` の変更は`posterior_encoder` 関連のコードでは使われていないので影響なし

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足
テストコードですべて動作確認済み．各種モジュールの使い方はテストコード参照．
decoderは仮実装であり，抽象クラスの継承など行っていない．
