### PR TITLE
Agent modelとWorld modelの抽象クラスを追加し、テスト用のダミー具象クラスを実装しました。 

### DIFF
--- a/src/models/abc/agent.py
+++ b/src/models/abc/agent.py
@@ -24,7 +24,6 @@ class Agent(ABC):
         Args:
             controller (Controller): Instance of Controller model class.
             transition (Transition): Instance of Transition model class.
-            prior (Prior): Instance of Prior model class.
             obs_encoder (ObservationEncoder): Instance of Observation Encoder model class.
         """
 
@@ -48,6 +47,7 @@ class Agent(ABC):
         Args:
             obs (_tensor_or_any): Observation from environment.
             target (_tensor_or_any): Target sound data from environment.
+            probabilistic (bool): If True, generate action from probability distribution.
 
         Returns:
             action (_tensor_or_any): Action for stepping environment.

--- a/src/models/abc/agent.py
+++ b/src/models/abc/agent.py
@@ -1,0 +1,82 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+import torch
+
+from ._types import _tensor_or_any
+from .controller import Controller
+from .observation_auto_encoder import ObservationEncoder
+from .transition import Transition
+
+
+class Agent(ABC):
+    """Abstract agent model *interface* class."""
+
+    def __init__(
+        self,
+        controller: Controller,
+        transition: Transition,
+        obs_encoder: ObservationEncoder,
+        *args: Any,
+        **kwds: Any
+    ) -> None:
+        """
+        Args:
+            controller (Controller): Instance of Controller model class.
+            transition (Transition): Instance of Transition model class.
+            prior (Prior): Instance of Prior model class.
+            obs_encoder (ObservationEncoder): Instance of Observation Encoder model class.
+        """
+
+        self.controller = controller
+        self.transition = transition
+        self.obs_encoder = obs_encoder
+
+        self.hidden = torch.zeros(1, *transition.hidden_shape)
+        self.controller_hidden = torch.zeros(1, *controller.controller_hidden_shape)
+
+        # Throw device location management to `nn.Module`.
+        self.transition.register_buffer("_hidden_of_agent", self.hidden, False)
+        self.controller.register_buffer(
+            "_controller_hidden_of_agent", self.controller_hidden, False
+        )
+
+    def act(
+        self, obs: _tensor_or_any, target: _tensor_or_any, probabilistic: bool
+    ) -> _tensor_or_any:
+        """Take action using input observation.
+        Args:
+            obs (_tensor_or_any): Observation from environment.
+            target (_tensor_or_any): Target sound data from environment.
+
+        Returns:
+            action (_tensor_or_any): Action for stepping environment.
+        """
+        state = self.obs_encoder.forward(self.hidden, obs).sample()
+        action, controller_hidden = self.controller.forward(
+            self.hidden, state, target, self.controller_hidden, probabilistic=probabilistic
+        )
+
+        # Update internal hidden state.
+        self.hidden = self.transition.forward(self.hidden, state, action)
+        self.controller_hidden = controller_hidden
+
+        return action
+
+    @abstractmethod
+    def explore(self, obs: _tensor_or_any, target: _tensor_or_any) -> _tensor_or_any:
+        """Take action for exploring environment using input observation.
+
+        Args:
+            obs (_tensor_or_any): Observation from environment.
+            target (_tensor_or_any): Target sound data from environment.
+
+        Returns:
+            action (_tensor_or_any): Action for exploring environment.
+        """
+        pass
+
+    def reset(self):
+        """Reset internal hidden states."""
+        self.hidden.zero_()
+        self.controller_hidden.zero_()

--- a/src/models/abc/world.py
+++ b/src/models/abc/world.py
@@ -1,0 +1,67 @@
+from typing import Any
+
+import torch.nn as nn
+from torch.distributions import Distribution
+
+from ._types import _t_or_any, _tensor_or_any
+from .observation_auto_encoder import ObservationDecoder, ObservationEncoder
+from .prior import Prior
+from .transition import Transition
+
+_dist_or_any = _t_or_any[Distribution]
+
+
+class World:
+    """Abstract world model *interface* class."""
+
+    def __init__(
+        self,
+        transition: Transition,
+        prior: Prior,
+        obs_encoder: ObservationEncoder,
+        obs_decoder: ObservationDecoder,
+        *args: Any,
+        **kwds: Any,
+    ) -> None:
+        """
+        Args:
+            transition (Transition): Instance of Transition model class.
+            prior (Prior): Instance of Prior model class.
+            obs_encoder (ObservationEncoder): Instance of Observation Encoder class.
+            obs_decoder (ObservationDecoder): Instance of Observation Decoder class.
+        """
+        super().__init__()
+
+        self.transition = transition
+        self.prior = prior
+        self.obs_encoder = obs_encoder
+        self.obs_decoder = obs_decoder
+
+    def forward(
+        self,
+        hidden: _tensor_or_any,
+        state: _tensor_or_any,
+        action: _tensor_or_any,
+        next_obs: _tensor_or_any,
+        *args: Any,
+        **kwds: Any,
+    ) -> tuple[_dist_or_any, _dist_or_any, _tensor_or_any]:
+        """Make world model transition.
+
+        Args:
+            hidden (_tensor_or_any): hidden state `h_t`.
+            state (_tensor_or_any): world 'state' `s_t`,
+            action (_tensor_or_any): action array data `a_t`,
+            next_obs (_tensor_or_any): next step observation data `o_{t+1}`
+
+        Returns:
+            next_state_prior (_dist_or_any): Next state by prior. `s^_{t+1}`
+            next_state_posterior (_dist_or_any): Next state by Observation Encoder. `s_{t+1}`
+            next_hidden (_tensor_or_any): Next hidden state. `h_{t+1}`
+        """
+
+        next_hidden = self.transition.forward(hidden, state, action)
+        next_state_prior = self.prior.forward(next_hidden)
+        next_state_posterior = self.obs_encoder.forward(next_hidden, next_obs)
+
+        return next_state_prior, next_state_posterior, next_hidden

--- a/tests/models/abc/dummy_classes.py
+++ b/tests/models/abc/dummy_classes.py
@@ -1,0 +1,123 @@
+from typing import Any
+
+import torch
+from torch import Tensor
+from torch.distributions import Normal
+
+from src.models.abc.controller import Controller
+from src.models.abc.observation_auto_encoder import (
+    ObservationDecoder,
+    ObservationEncoder,
+)
+from src.models.abc.prior import Prior
+from src.models.abc.transition import Transition
+
+
+class DummyTransition(Transition):
+    """Dummy transition model class for testing."""
+
+    def __init__(self, hidden_shape: tuple[int], *args: Any, **kwds: Any) -> None:
+        super().__init__()
+        self._hidden_shape = hidden_shape
+
+    def forward(self, hidden: Tensor, state: Tensor, action: Tensor) -> Tensor:
+        return torch.randn(hidden.shape)
+
+    @property
+    def hidden_shape(self) -> tuple[int]:
+        return self._hidden_shape
+
+
+class DummyPrior(Prior):
+    """Dummy prior model class for testing."""
+
+    def __init__(self, state_shape: tuple[int], *args: Any, **kwds: Any) -> None:
+        super().__init__()
+        self._state_shape = state_shape
+
+    def forward(self, hidden: Tensor) -> Normal:
+        shape = (hidden.size(0), *self.state_shape)
+        mean = torch.zeros(shape).type_as(hidden)
+        std = torch.ones_like(mean)
+        return Normal(mean, std)
+
+    @property
+    def state_shape(self) -> tuple[int]:
+        return self._state_shape
+
+
+class DummyObservationEncoder(ObservationEncoder):
+    """Dummy observation encoder model class for testing."""
+
+    def __init__(
+        self, state_shape: tuple[int], embedded_obs_shape: tuple[int], *args: Any, **kwds: Any
+    ) -> None:
+        super().__init__()
+        self._state_shape = state_shape
+        self.embedded_obs_shape = embedded_obs_shape
+
+    def embed_observation(self, obs: tuple[Tensor, Tensor]) -> Tensor:
+        v, g = obs
+        shape = (v.size(0), *self.embedded_obs_shape)
+        return torch.randn(shape).type_as(v)
+
+    def encode(self, hidden: Tensor, embedded_obs: Tensor) -> Normal:
+        shape = (hidden.size(0), *self.state_shape)
+        mean = torch.zeros(shape).type_as(hidden)
+        std = torch.ones_like(mean)
+        return Normal(mean, std)
+
+    @property
+    def state_shape(self) -> tuple[int]:
+        return self._state_shape
+
+
+class DummyObservationDecoder(ObservationDecoder):
+    """Dummy observation decoder model class for testing."""
+
+    def __init__(
+        self,
+        voc_state_shape: tuple[int],
+        generated_sound_shape: tuple[int],
+        *args: Any,
+        **kwds: Any
+    ) -> None:
+        super().__init__()
+        self._voc_state_shape = voc_state_shape
+        self._generated_sound_shape = generated_sound_shape
+
+    def forward(self, hidden: Tensor, state: Tensor) -> Tensor:
+        vs_shape = (hidden.size(0), *self._voc_state_shape)
+        gs_shape = (hidden.size(0), *self._generated_sound_shape)
+        return torch.randn(vs_shape).type_as(hidden), torch.randn(gs_shape).type_as(hidden)
+
+
+class DummyController(Controller):
+    """Dummy controller model class for testing."""
+
+    def __init__(
+        self,
+        action_shape: tuple[int],
+        controller_hidden_shape: tuple[int],
+        *args: Any,
+        **kwds: Any
+    ) -> None:
+        super().__init__()
+
+        self._action_shape = action_shape
+        self._controller_hidden_shape = controller_hidden_shape
+
+    def forward(
+        self,
+        hidden: Tensor,
+        state: Tensor,
+        target: Tensor,
+        controller_hidden: Tensor,
+        probabilistic: bool,
+    ) -> tuple[Tensor, Tensor]:
+        shape = (hidden.size(0), *self._action_shape)
+        return torch.rand(shape) * 2 + 0.5, torch.randn_like(controller_hidden)
+
+    @property
+    def controller_hidden_shape(self) -> tuple[int]:
+        return self._controller_hidden_shape

--- a/tests/models/abc/dummy_classes.py
+++ b/tests/models/abc/dummy_classes.py
@@ -4,6 +4,7 @@ import torch
 from torch import Tensor
 from torch.distributions import Normal
 
+from src.models.abc.agent import Agent
 from src.models.abc.controller import Controller
 from src.models.abc.observation_auto_encoder import (
     ObservationDecoder,
@@ -11,6 +12,7 @@ from src.models.abc.observation_auto_encoder import (
 )
 from src.models.abc.prior import Prior
 from src.models.abc.transition import Transition
+from src.models.abc.world import World
 
 
 class DummyTransition(Transition):
@@ -121,3 +123,17 @@ class DummyController(Controller):
     @property
     def controller_hidden_shape(self) -> tuple[int]:
         return self._controller_hidden_shape
+
+
+class DummyWorld(World):
+    """Dummy world model interface class for testing."""
+
+    pass
+
+
+class DummyAgent(Agent):
+    """Dummy agent model interface class for testing."""
+
+    def explore(self, obs: tuple[Tensor, Tensor], target: Tensor) -> Tensor:
+        action = self.act(obs, target, True)
+        return action

--- a/tests/models/abc/test_agent.py
+++ b/tests/models/abc/test_agent.py
@@ -1,0 +1,74 @@
+import copy
+
+import pytest
+import torch
+from torch import Tensor
+
+from src.models.abc import agent as mod
+from tests.models.abc.dummy_classes import (
+    DummyController,
+    DummyObservationEncoder,
+    DummyTransition,
+)
+
+batch_size = 1  # constant 1.
+hidden_shape = (16,)
+state_shape = (32,)
+action_shape = (7,)
+voc_state_shape = (44,)
+generated_sound_shape = (80, 5)
+target_sound_shape = generated_sound_shape
+embedded_obs_shape = (64,)
+controller_hidden_shape = (16,)
+
+
+hidden = torch.randn(batch_size, *hidden_shape)
+state = torch.randn(batch_size, *state_shape)
+action = torch.randn(batch_size, *action_shape)
+voc_state = torch.rand(batch_size, *voc_state_shape)
+generated_sound = torch.randn(batch_size, *generated_sound_shape) ** 2
+target_sound = torch.randn(batch_size, *target_sound_shape) ** 2
+embedded_obs = torch.randn(batch_size, *embedded_obs_shape)
+controller_hidden = torch.randn(batch_size, *controller_hidden_shape)
+
+dummy_trans = DummyTransition(hidden_shape)
+dummy_obs_enc = DummyObservationEncoder(state_shape, embedded_obs_shape)
+dummy_controller = DummyController(action_shape, controller_hidden_shape)
+
+
+def test_Agent():
+    cls = mod.Agent
+    dum_con = copy.deepcopy(dummy_controller)  # ignore buffer modification
+    dum_trn = copy.deepcopy(dummy_trans)  # ignore buffer modification
+
+    with pytest.raises(TypeError) as e:
+        cls(dum_con, dum_trn, dummy_obs_enc)
+
+    class C(cls):
+        def explore(self, obs: tuple[Tensor, Tensor], target: Tensor) -> Tensor:
+            return self.act(obs, target, True)
+
+    obj = C(dum_con, dum_trn, dummy_obs_enc)
+
+    assert "_hidden_of_agent" in dum_trn._buffers
+    assert "_controller_hidden_of_agent" in dum_con._buffers
+    assert dum_trn._buffers["_hidden_of_agent"] is obj.hidden
+    assert dum_con._buffers["_controller_hidden_of_agent"] is obj.controller_hidden
+
+    assert obj.hidden.shape == (1, *hidden_shape)
+    assert obj.controller_hidden.shape == (1, *controller_hidden_shape)
+    assert (obj.hidden == 0.0).all()
+    assert (obj.controller_hidden == 0.0).all()
+
+    next_action = obj.act(
+        obs=(voc_state, generated_sound), target=target_sound, probabilistic=False
+    )
+
+    assert not (obj.hidden == 0.0).all()
+    assert not (obj.controller_hidden == 0.0).all()
+    assert next_action.shape == action.shape
+    obj.explore(obs=(voc_state, generated_sound), target=target_sound)
+
+    obj.reset()
+    assert (obj.hidden == 0.0).all()
+    assert (obj.controller_hidden == 0.0).all()

--- a/tests/models/abc/test_dummy_classes.py
+++ b/tests/models/abc/test_dummy_classes.py
@@ -1,0 +1,75 @@
+import torch
+
+from tests.models.abc import dummy_classes as mod
+
+batch_size = 8
+hidden_shape = (16,)
+state_shape = (32,)
+action_shape = (7,)
+voc_state_shape = (44,)
+generated_sound_shape = (80, 5)
+target_sound_shape = generated_sound_shape
+embedded_obs_shape = (64,)
+controller_hidden_shape = (16,)
+
+
+hidden = torch.randn(batch_size, *hidden_shape)
+state = torch.randn(batch_size, *state_shape)
+action = torch.randn(batch_size, *action_shape)
+voc_state = torch.rand(batch_size, *voc_state_shape)
+generated_sound = torch.randn(batch_size, *generated_sound_shape) ** 2
+target_sound = torch.randn(batch_size, *target_sound_shape) ** 2
+embedded_obs = torch.randn(batch_size, *embedded_obs_shape)
+controller_hidden = torch.randn(batch_size, *controller_hidden_shape)
+
+
+def test_DummyTransition():
+    cls = mod.DummyTransition
+
+    obj = cls(hidden_shape)
+    assert obj.forward(hidden, state, action).shape == hidden.shape
+    assert obj.hidden_shape == hidden_shape
+
+
+def test_DummyPrior():
+    cls = mod.DummyPrior
+
+    obj = cls(state_shape)
+    assert obj.state_shape == state_shape
+    out = obj.forward(hidden)
+    assert isinstance(out, torch.distributions.Normal)
+    assert out.sample().shape == state.shape
+
+
+def test_DummyObservationEncoder():
+    cls = mod.DummyObservationEncoder
+
+    obj = cls(state_shape, embedded_obs_shape)
+
+    assert obj.state_shape == state_shape
+    assert obj.embed_observation((voc_state, generated_sound)).shape == embedded_obs.shape
+    out = obj.encode(hidden, embedded_obs)
+    assert isinstance(out, torch.distributions.Normal)
+    assert out.sample().shape == state.shape
+
+
+def test_DummyObservationDecoder():
+    cls = mod.DummyObservationDecoder
+
+    obj = cls(voc_state_shape, generated_sound_shape)
+
+    out_v, out_g = obj.forward(hidden, state)
+    assert out_v.shape == voc_state.shape
+    assert out_g.shape == generated_sound.shape
+
+
+def test_DummyController():
+    cls = mod.DummyController
+    obj = cls(action_shape, controller_hidden_shape)
+
+    assert obj.controller_hidden_shape == controller_hidden_shape
+    out_action, next_controller_hidden = obj.forward(
+        hidden, state, target_sound, controller_hidden, True
+    )
+    assert out_action.shape == action.shape
+    assert next_controller_hidden.shape == controller_hidden.shape

--- a/tests/models/abc/test_world.py
+++ b/tests/models/abc/test_world.py
@@ -1,0 +1,48 @@
+import torch
+
+from src.models.abc import world as mod
+from tests.models.abc.dummy_classes import (
+    DummyObservationDecoder,
+    DummyObservationEncoder,
+    DummyPrior,
+    DummyTransition,
+)
+
+batch_size = 8
+hidden_shape = (16,)
+state_shape = (32,)
+action_shape = (7,)
+voc_state_shape = (44,)
+generated_sound_shape = (80, 5)
+target_sound_shape = generated_sound_shape
+embedded_obs_shape = (64,)
+
+
+hidden = torch.randn(batch_size, *hidden_shape)
+state = torch.randn(batch_size, *state_shape)
+action = torch.randn(batch_size, *action_shape)
+voc_state = torch.rand(batch_size, *voc_state_shape)
+generated_sound = torch.randn(batch_size, *generated_sound_shape) ** 2
+target_sound = torch.randn(batch_size, *target_sound_shape) ** 2
+embedded_obs = torch.randn(batch_size, *embedded_obs_shape)
+
+dummy_trans = DummyTransition(hidden_shape)
+dummy_prior = DummyPrior(state_shape)
+dummy_obs_enc = DummyObservationEncoder(state_shape, embedded_obs_shape)
+dummy_obs_dec = DummyObservationDecoder(voc_state_shape, generated_sound_shape)
+
+
+def test_World():
+    cls = mod.World
+
+    obj = cls(dummy_trans, dummy_prior, dummy_obs_enc, dummy_obs_dec)
+
+    next_state_prior, next_state_post, next_hidden = obj.forward(
+        hidden, state, action, next_obs=(voc_state, generated_sound)
+    )
+
+    assert isinstance(next_state_prior, torch.distributions.Normal)
+    assert isinstance(next_state_post, torch.distributions.Normal)
+    assert next_state_prior.sample().shape == next_state_post.sample().shape
+    assert next_state_prior.sample().shape == state.shape
+    assert next_hidden.shape == hidden.shape


### PR DESCRIPTION
## 概要
#18 Agent modelとWorld modelの抽象クラスを追加し、テスト用のダミー具象クラスを実装しました。 
<!-- 変更の目的 もしくは 関連する Issue 番号 -->

## 変更内容
- インターフェイス用抽象クラス`World`を`src/models/abc/world.py`に実装
- インターフェイス用抽象クラス`Agent`を`src/models/abc/agent.py`に実装
- すべての抽象クラスに対しテスト用具象クラスを `tests/models/abc/dummy_classes.py`に実装
- 上記の実装のテストコードを追加

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲
- src/models/abc/ 下のファイル
- tests/models/abc 下のファイル 

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
