### PR TITLE
train.pyのエントリーポイントをhydraを用いて実装しました。  

### DIFF
--- a/.project-root
+++ b/.project-root
@@ -1,0 +1,2 @@
+# this file is required for inferring the project root directory
+# do not delete

--- a/configs/README.md
+++ b/configs/README.md
@@ -1,15 +1,29 @@
-設定ファイルに関するドキュメントをここに書きます。
+設定ファイルに関するドキュメントをここに書きます。基本的にhydraを使用することを想定し、`yaml`を用いて記述していくことを検討しています。[基本的な構成は`lightning-hydra-template`を参考に行います。](https://github.com/ashleve/lightning-hydra-template/tree/main/configs)
 
-## Hydra
+## configs
 
-基本的にhydraを使用することを想定し、`yaml`を用いて記述していくことを検討しています。
-https://github.com/ashleve/lightning-hydra-template/tree/main/configs
+### train.yaml
+
+`src/train.py`を実行した際に一番最初に読み込まれる設定ファイルです。
+モデルの設定ファイル、データセットの設定ファイルといった、学習処理全体にかかわる設定をここで指定します。
+
+### paths/\*.yaml
+
+ルートディレクトリ、データディレクトリ、ログディレクトリなどを指定します。
+他のconfigファイルからは`${paths.some_dir}`という形式で参照することが出来ます。
+
+### hydra/\*.yaml
+
+hydraモジュールの設定を行います。[詳細はhydraの公式ドキュメントを参照願います。](https://hydra.cc/docs/configure_hydra/intro/)
+
+## Hydraについて
 
 https://hydra.cc/docs/intro/
 
 ### hydra.main
 
-wip
+このデコレーターを付与した関数がエントリーポイントとなります。[`hydra.main`の実行例は`src/train.py`をご確認ください。](/src/train.py)
+ここで読み込まれた設定ファイルの中身は属性参照`cfg.value_name`によって取得することができます。
 
 ### hydra.utils.instantiate
 

--- a/configs/hydra/default.yaml
+++ b/configs/hydra/default.yaml
@@ -1,0 +1,13 @@
+# https://hydra.cc/docs/configure_hydra/intro/
+
+# enable color logging
+defaults:
+  - override hydra_logging: colorlog
+  - override job_logging: colorlog
+
+# output directory, generated dynamically on each run
+run:
+  dir: ${paths.log_dir}/${task_name}/runs/${now:%Y-%m-%d}_${now:%H-%M-%S}
+sweep:
+  dir: ${paths.log_dir}/${task_name}/multiruns/${now:%Y-%m-%d}_${now:%H-%M-%S}
+  subdir: ${hydra.job.num}

--- a/configs/paths/default.yaml
+++ b/configs/paths/default.yaml
@@ -1,0 +1,18 @@
+# path to root directory
+# this requires PROJECT_ROOT environment variable to exist
+# you can replace it with "." if you want the root to be the current working directory
+root_dir: ${oc.env:PROJECT_ROOT}
+
+# path to data directory
+data_dir: ${paths.root_dir}/data/
+
+# path to logging directory
+log_dir: ${paths.root_dir}/logs/
+
+# path to output directory, created dynamically by hydra
+# path generation pattern is specified in `configs/hydra/default.yaml`
+# use it to store all files generated during the run, like ckpts and metrics
+output_dir: ${hydra:runtime.output_dir}
+
+# path to working directory
+work_dir: ${hydra:runtime.cwd}

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -1,0 +1,32 @@
+# @package _global_
+
+# copied from https://github.com/ashleve/lightning-hydra-template/blob/main/configs/train.yaml
+
+# specify here default configuration
+# order of defaults determines the order in which configs override each other
+defaults:
+  - _self_
+  - paths: default.yaml
+  - hydra: default.yaml
+
+task_name: "train"
+
+# tags to help you identify your experiments
+# you can overwrite this in experiment configs
+# overwrite from command line with `python train.py tags="[first_tag, second_tag]"`
+# appending lists from command line is currently not supported :(
+# https://github.com/facebookresearch/hydra/issues/1547
+tags: ["dev"]
+
+# set False to skip model training
+train: True
+
+# evaluate on test set, using best model weights achieved during training
+# lightning chooses best weights based on the metric specified in checkpoint callback
+eval: True
+
+# simply provide checkpoint path to resume training
+ckpt_path: null
+
+# seed for random number generators in pytorch, numpy and python.random
+seed: null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,11 @@ pytest = "^7.2.0"
 torch = "^1.13.1"
 librosa = "^0.9.2"
 torch-complex = "^0.4.3"
+hydra-core = "^1.3.1"
+hydra-colorlog = "^1.2.0"
+hydra-optuna-sweeper = "^1.2.0"
+pyrootutils = "^1.0.4"
+rich = "^13.2.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"

--- a/src/train.py
+++ b/src/train.py
@@ -1,1 +1,45 @@
 # このファイルは直接実行するため、相対import文を記述しないでください。
+import logging
+from typing import Optional
+
+import hydra
+import pyrootutils
+from omegaconf import DictConfig
+
+pyrootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
+
+# Copied from https://github.com/ashleve/lightning-hydra-template/blob/main/src/train.py
+# ------------------------------------------------------------------------------------ #
+# the setup_root above is equivalent to:
+# - adding project root dir to PYTHONPATH
+#       (so you don't need to force user to install project as a package)
+#       (necessary before importing any local modules e.g. `from src import utils`)
+# - setting up PROJECT_ROOT environment variable
+#       (which is used as a base for paths in "configs/paths/default.yaml")
+#       (this way all filepaths are the same no matter where you run the code)
+# - loading environment variables from ".env" in root dir
+#
+# you can remove it if you:
+# 1. either install project as a package or move entry files to project root dir
+# 2. set `root_dir` to "." in "configs/paths/default.yaml"
+#
+# more info: https://github.com/ashleve/pyrootutils
+# ------------------------------------------------------------------------------------ #
+
+logger = logging.getLogger(__name__)
+
+
+def train(cfg: DictConfig) -> None:
+    """Trains the model."""
+    logger.info("Training started!")
+
+
+@hydra.main(version_base="1.3", config_path="../configs", config_name="train.yaml")
+def main(cfg: DictConfig) -> Optional[float]:
+
+    # train the model
+    train(cfg)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要
#17 学習のエントリーポイントを`src/train.py`にhydraを用いて実装しました。  
それに伴って作成が必要になった設定ファイルおよびそれらについてのドキュメント、依存関係となるモジュールを追加しました。 

<!-- 変更の目的 もしくは 関連する Issue 番号 -->

## 変更内容
- src/train.pyにエントリーポイントを追加
- pyproject.tomlに依存関係を追加
- configs/以下にエントリーポイントに必要な設定ファイルを追加
- config/README.mdに各種configファイルの説明を追加
- config/README.mdにhydra.mainについての説明を追加  
- .project-rootをルートディレクトリナビゲーションのために追加  

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲
- .project-root
- configs以下のファイル
- pyproject.toml
- src/train.py

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
