### PR TITLE
PriorEncoderの実装

### DIFF
--- a/src/models/components/prior_encoder.py
+++ b/src/models/components/prior_encoder.py
@@ -4,11 +4,11 @@ import torch.nn.functional as F
 from torch.distributions import Distribution
 from torch.distributions.normal import Normal
 
-from ..abc.prior import Prior
+from ..abc.prior import Prior as AbstractPrior
 from ..abc._types import _t_or_any, _tensor_or_any
 
 
-class Prior(Prior):
+class Prior(AbstractPrior):
     def __init__(self, hidden_dim: int, state_dim: int, min_stddev: float = 0.1) -> None:
         """
         Args:

--- a/src/models/components/prior_encoder.py
+++ b/src/models/components/prior_encoder.py
@@ -10,6 +10,12 @@ from ..abc._types import _t_or_any, _tensor_or_any
 
 class Prior(Prior):
     def __init__(self, hidden_dim: int, state_dim: int, min_stddev: float = 0.1) -> None:
+        """
+        Args:
+            hidden_dim (int): The length of Hidden dimention
+            state_dim (int): The length of State dimention
+            min_stddev (float, optional): inimum value of standart deviation. Defaults to 0.1.
+        """
         super().__init__()
         self.hidden_dim = hidden_dim
         self.state_dim = state_dim
@@ -22,6 +28,13 @@ class Prior(Prior):
         self.fc_to_stddev = nn.Linear(hidden_dim, state_dim)
 
     def forward(self, hidden: _tensor_or_any) -> _t_or_any[Distribution]:
+        """
+        Args:
+            hidden (_tensor_or_any): Hidden vectors computed deterministically.
+
+        Returns:
+            _t_or_any[Distribution]: The Normal distribution 
+        """
         mean = self.fc_to_mean(hidden)
         stddev = (
             F.softplus(self.fc_to_stddev(hidden)) + self.min_stddev
@@ -30,4 +43,9 @@ class Prior(Prior):
 
     @property
     def state_shape(self) -> tuple[int]:
+        """The getter of the shape of state.
+
+        Returns:
+            tuple[int]: The size of state dimention.
+        """
         return (self.state_dim,)

--- a/src/models/components/prior_encoder.py
+++ b/src/models/components/prior_encoder.py
@@ -1,0 +1,13 @@
+import torch
+import torch.nn as nn
+from torch.distributions import Distribution
+
+from ..abc import prior
+from ..abc._types import _t_or_any, _tensor_or_any
+
+class Prior(prior.Prior):
+    def __init__(self, hidden_dim: int, state_dim:int)-> None:
+        pass
+
+    def forward(self, hidden: _tensor_or_any) -> _t_or_any[Distribution]:
+        pass

--- a/src/models/components/prior_encoder.py
+++ b/src/models/components/prior_encoder.py
@@ -1,13 +1,20 @@
 import torch
 import torch.nn as nn
 from torch.distributions import Distribution
+from torch.distributions.normal import Normal
 
 from ..abc import prior
 from ..abc._types import _t_or_any, _tensor_or_any
 
+
 class Prior(prior.Prior):
-    def __init__(self, hidden_dim: int, state_dim:int)-> None:
-        pass
+    def __init__(self, hidden_dim: int, state_dim: int) -> None:
+        assert hidden_dim > 0, "hidden_dim must be greater than 0"
+        assert state_dim > 0, "state_dim must be greater than 0"
+        self.fc_to_mean = nn.Linear(hidden_dim, state_dim)
+        self.fc_to_var = nn.Linear(hidden_dim, state_dim)
 
     def forward(self, hidden: _tensor_or_any) -> _t_or_any[Distribution]:
-        pass
+        mean = self.fc_to_mean(hidden)
+        var = self.fc_to_var(hidden)
+        return Normal(mean, var)

--- a/src/models/components/prior_encoder.py
+++ b/src/models/components/prior_encoder.py
@@ -28,5 +28,6 @@ class Prior(prior.Prior):
         )  # Follows the code of exercise7
         return Normal(mean, stddev)
 
+    @property
     def state_shape(self) -> tuple[int]:
         return (self.state_dim,)

--- a/src/models/components/prior_encoder.py
+++ b/src/models/components/prior_encoder.py
@@ -1,5 +1,6 @@
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from torch.distributions import Distribution
 from torch.distributions.normal import Normal
 
@@ -8,13 +9,24 @@ from ..abc._types import _t_or_any, _tensor_or_any
 
 
 class Prior(prior.Prior):
-    def __init__(self, hidden_dim: int, state_dim: int) -> None:
+    def __init__(self, hidden_dim: int, state_dim: int, min_stddev: float = 0.1) -> None:
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.state_dim = state_dim
+        self.min_stddev = min_stddev
+
         assert hidden_dim > 0, "hidden_dim must be greater than 0"
         assert state_dim > 0, "state_dim must be greater than 0"
+
         self.fc_to_mean = nn.Linear(hidden_dim, state_dim)
-        self.fc_to_var = nn.Linear(hidden_dim, state_dim)
+        self.fc_to_stddev = nn.Linear(hidden_dim, state_dim)
 
     def forward(self, hidden: _tensor_or_any) -> _t_or_any[Distribution]:
         mean = self.fc_to_mean(hidden)
-        var = self.fc_to_var(hidden)
-        return Normal(mean, var)
+        stddev = (
+            F.softplus(self.fc_to_stddev(hidden)) + self.min_stddev
+        )  # Follows the code of exercise7
+        return Normal(mean, stddev)
+
+    def state_shape(self) -> tuple[int]:
+        return (self.state_dim,)

--- a/src/models/components/prior_encoder.py
+++ b/src/models/components/prior_encoder.py
@@ -4,11 +4,11 @@ import torch.nn.functional as F
 from torch.distributions import Distribution
 from torch.distributions.normal import Normal
 
-from ..abc import prior
+from ..abc.prior import Prior
 from ..abc._types import _t_or_any, _tensor_or_any
 
 
-class Prior(prior.Prior):
+class Prior(Prior):
     def __init__(self, hidden_dim: int, state_dim: int, min_stddev: float = 0.1) -> None:
         super().__init__()
         self.hidden_dim = hidden_dim

--- a/tests/models/components/test_prior_encoder.py
+++ b/tests/models/components/test_prior_encoder.py
@@ -7,7 +7,7 @@ hidden_dim = 10
 invalid_hidden_dim = -1
 state_dim = 5
 invalid_state_dim = -1
-
+batch_size = 4
 
 def test__init__():
     with pytest.raises(AssertionError):
@@ -18,9 +18,15 @@ def test__init__():
 
 def test_forward():
     model = Prior(hidden_dim, state_dim)
+    # single input
     random_input = torch.rand((hidden_dim,), requires_grad=True)
     state_distribution = model(random_input)
     assert state_distribution.sample().shape == (state_dim,)
+    assert state_distribution.rsample().requires_grad == True
+    # batch input
+    random_input = torch.rand((batch_size, hidden_dim), requires_grad=True)
+    state_distribution = model(random_input)
+    assert state_distribution.sample().shape == (batch_size, state_dim)
     assert state_distribution.rsample().requires_grad == True
 
 

--- a/tests/models/components/test_prior_encoder.py
+++ b/tests/models/components/test_prior_encoder.py
@@ -1,0 +1,29 @@
+import pytest
+import torch
+
+from src.models.components.prior_encoder import Prior
+
+hidden_dim = 10
+invalid_hidden_dim = -1
+state_dim = 5
+invalid_state_dim = -1
+
+
+def test__init__():
+    with pytest.raises(AssertionError):
+        model = Prior(invalid_hidden_dim, state_dim)
+    with pytest.raises(AssertionError):
+        model = Prior(hidden_dim, invalid_state_dim)
+
+
+def test_forward():
+    model = Prior(hidden_dim, state_dim)
+    random_input = torch.rand((hidden_dim,), requires_grad=True)
+    state_distribution = model(random_input)
+    assert state_distribution.sample().shape == (state_dim,)
+    assert state_distribution.rsample().requires_grad == True
+
+
+def test_state_shape():
+    model = Prior(hidden_dim, state_dim)
+    assert model.state_shape == (state_dim,)


### PR DESCRIPTION
## 概要
#19 
PriorEncoderを実装します
事前の打ち合わせ通りとりあえずLinear一層による実装になっています
採用する活性化関数などは演習のコードに従っています

## 変更内容
- src/models/components/prior_encoder.pyを追加
- tests/models/components/test_prior_encoder.pyを追加


## 影響範囲
現時点での影響ファイルは下記のみ
- src/models/components/prior_encoder.py
- tests/models/components/test_prior_encoder.py

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足
自分の担当を勘違いして実装始めちゃいました。
