### PR TITLE
行動の値域を[-1,1]にするNormalizeActionRangeクラスを実装

### DIFF
--- a/src/env/normalize_action_range.py
+++ b/src/env/normalize_action_range.py
@@ -1,0 +1,57 @@
+from collections import OrderedDict
+
+import gym
+import numpy as np
+from gym import spaces
+
+
+class NormalizeActionRange(gym.ActionWrapper):
+    """Normalize Action Range of Action Wrapper.
+
+    Fix action range to [-1, 1].
+    """
+
+    def __init__(self, env: gym.Env, low: float = -1.0, high: float = 1.0) -> None:
+        """
+        Args:
+            env (gym.Env): PynkTromboneGym Env or its wrapper.
+        """
+        super().__init__(env)
+        self.low = low
+        self.high = high
+
+        self.action_space = self.define_action_space()
+
+    action_space: spaces.Dict
+
+    def define_action_space(self):
+        """Re define action space of environment."""
+        orig_space: spaces.Dict = self.env.action_space
+
+        new_space = dict()
+        for (name, box) in orig_space.items():
+            new_space[name] = spaces.Box(self.low, self.high, box.shape, dtype=box.dtype)
+
+        return spaces.Dict(new_space)
+
+    def inv_normalized_action_range(self, dict_action: OrderedDict) -> OrderedDict:
+        """Inverse normalized action range for original environment.
+        Args:
+            dict_action (spaces.Dict): Normalized dict action.
+
+        Returns:
+            inv_dict_action (spaces.Dict): Inv-normalized dict action.
+        """
+        inv_dict_action = OrderedDict()
+
+        for (name, action) in dict_action.items():
+            action: np.ndarray
+            sp: spaces.Box = self.env.action_space[name]
+            inv = (action * (sp.high - sp.low) + (sp.high + sp.low)) / 2
+            inv_dict_action[name] = inv
+
+        return inv_dict_action
+
+    def action(self, action: OrderedDict) -> OrderedDict:
+        """Wraps action."""
+        return self.inv_normalized_action_range(action)

--- a/src/env/normalize_action_range.py
+++ b/src/env/normalize_action_range.py
@@ -15,6 +15,8 @@ class NormalizeActionRange(gym.ActionWrapper):
         """
         Args:
             env (gym.Env): PynkTromboneGym Env or its wrapper.
+            low (float): The lowest value of normalized action.
+            high (float): The highest value of normalized action.
         """
         super().__init__(env)
         self.low = low

--- a/tests/env/test_normalize_action_range.py
+++ b/tests/env/test_normalize_action_range.py
@@ -1,0 +1,64 @@
+import numpy as np
+import pytest
+from gym.spaces import Box
+from pynktrombonegym.env import PynkTrombone
+
+from src.env import normalize_action_range as mod
+from tests.helpers.paths import sample_target_sound_file_pathes
+
+cls = mod.NormalizeActionRange
+
+
+def test__init__():
+    base_env = PynkTrombone(sample_target_sound_file_pathes)
+    low, high = -10.0, 10.0
+    env = cls(base_env, low, high)
+
+    assert env.low == low
+    assert env.high == high
+
+    for key in env.action_space.keys():
+        box: Box = env.action_space[key]
+        orig_box: Box = base_env.action_space[key]
+        assert box.low == low
+        assert box.high == high
+        assert box.shape == orig_box.shape
+        assert box.dtype == orig_box.dtype
+
+    del base_env
+
+
+@pytest.mark.parametrize("action_value", [-1.0, 0.0, 1.0])
+def test_inv_normalized_action_range(action_value: float):
+    base_env = PynkTrombone(sample_target_sound_file_pathes)
+    low, high = -1.0, 1.0
+    env = cls(base_env, low, high)
+
+    dict_action = env.action_space.sample()
+    for v in dict_action.values():
+        v[:] = action_value
+
+    inv_dict_action = env.inv_normalized_action_range(dict_action)
+    for key in inv_dict_action.keys():
+        inv_action = inv_dict_action[key]
+        orig_box: Box = base_env.action_space[key]
+
+        if action_value == -1.0:
+            actual = orig_box.low
+        elif action_value == 0.0:
+            actual = (orig_box.low + orig_box.high) / 2
+        elif action_value == 1.0:
+            actual = orig_box.high
+        else:
+            raise ValueError(f"Unexpected value: {action_value}")
+
+        np.testing.assert_allclose(inv_action, actual)
+
+
+def test_step_action():
+    base_env = PynkTrombone(sample_target_sound_file_pathes)
+    low, high = -1.0, 1.0
+    env = cls(base_env, low, high)
+
+    sample_action = env.action_space.sample()
+    env.step(sample_action)

--- a/tests/env/test_normalize_action_range.py
+++ b/tests/env/test_normalize_action_range.py
@@ -4,13 +4,13 @@ from gym.spaces import Box
 from pynktrombonegym.env import PynkTrombone
 
 from src.env import normalize_action_range as mod
-from tests.helpers.paths import sample_target_sound_file_pathes
+from tests.helpers.paths import sample_target_sound_file_paths
 
 cls = mod.NormalizeActionRange
 
 
 def test__init__():
-    base_env = PynkTrombone(sample_target_sound_file_pathes)
+    base_env = PynkTrombone(sample_target_sound_file_paths)
     low, high = -10.0, 10.0
     env = cls(base_env, low, high)
 
@@ -30,7 +30,7 @@ def test__init__():
 
 @pytest.mark.parametrize("action_value", [-1.0, 0.0, 1.0])
 def test_inv_normalized_action_range(action_value: float):
-    base_env = PynkTrombone(sample_target_sound_file_pathes)
+    base_env = PynkTrombone(sample_target_sound_file_paths)
     low, high = -1.0, 1.0
     env = cls(base_env, low, high)
 
@@ -56,7 +56,7 @@ def test_inv_normalized_action_range(action_value: float):
 
 
 def test_step_action():
-    base_env = PynkTrombone(sample_target_sound_file_pathes)
+    base_env = PynkTrombone(sample_target_sound_file_paths)
     low, high = -1.0, 1.0
     env = cls(base_env, low, high)
 

--- a/tests/helpers/paths.py
+++ b/tests/helpers/paths.py
@@ -1,0 +1,4 @@
+import glob
+
+sample_target_sounds_dir = "data/sample_target_sounds/*"
+sample_target_sound_file_pathes = glob.glob(sample_target_sounds_dir)

--- a/tests/helpers/paths.py
+++ b/tests/helpers/paths.py
@@ -1,4 +1,4 @@
 import glob
 
 sample_target_sounds_dir = "data/sample_target_sounds/*"
-sample_target_sound_file_pathes = glob.glob(sample_target_sounds_dir)
+sample_target_sound_file_paths = glob.glob(sample_target_sounds_dir)


### PR DESCRIPTION
## 概要
#35 PynkTromboneGym Environmentの行動の値域を[-1,1]の範囲に正規化するActionWrapperクラスを作成しました。  
<!-- 変更の目的 もしくは 関連する Issue 番号 -->

## 変更内容
- NormalizeActionRangeクラスを作成
- 上記クラスのテストコードを追加
- 補助変数としてデバッグ用音声ファイルリストを`tests/helpers/paths.pyに追加  


<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲
- ファイルの作成以外になし

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
