### PR TITLE
辞書型の行動を配列型で扱えるようにするActionWrapperクラスを実装しました。 

### DIFF
--- a/src/env/array_action.py
+++ b/src/env/array_action.py
@@ -1,0 +1,70 @@
+from collections import OrderedDict
+
+import gym
+import numpy as np
+from gym import spaces
+from pynktrombonegym.spaces import ActionSpaceNames as ASN
+
+ARRAY_ORDER = [
+    ASN.PITCH_SHIFT,
+    ASN.TENSENESS,
+    ASN.TRACHEA,
+    ASN.EPIGLOTTIS,
+    ASN.VELUM,
+    ASN.TONGUE_INDEX,
+    ASN.TONGUE_DIAMETER,
+    ASN.LIPS,
+]
+
+
+class ArrayAction(gym.ActionWrapper):
+    """Convert dict action space to array (Box) space."""
+
+    def __init__(self, env: gym.Env, new_step_api: bool = False):
+        """
+        Args:
+            env (gym.Env): PynkTromboneGym Env or its wrapper.
+            new_step_api (bool): Gym wrapper argument.
+        """
+        super().__init__(env, new_step_api)
+
+        self.action_space = self.define_action_space()
+
+    action_space: spaces.Box
+
+    def define_action_space(self) -> spaces.Box:
+        """Re-define action space of environment."""
+        orig_space: spaces.Dict = self.env.action_space
+
+        lows, highs = [], []
+        for name in ARRAY_ORDER:
+            orig_box: spaces.Box = orig_space[name]
+            lows.append(orig_box.low)
+            highs.append(orig_box.high)
+
+        lows = np.concatenate(lows)
+        highs = np.concatenate(highs)
+
+        box = spaces.Box(lows, highs, dtype=np.float32)
+
+        return box
+
+    def array_to_dict(self, array_action: np.ndarray) -> OrderedDict:
+        """Convert array action to dict action.
+        Args:
+            array_action (np.ndarray): Array of action parameters.
+
+        Returns:
+            dict_action (OrderedDict): Dictionary action for original environment.
+        """
+
+        assert len(array_action) == len(ARRAY_ORDER)
+        array_action = array_action.reshape(-1, 1)
+        dict_action = OrderedDict()
+        for i, name in enumerate(ARRAY_ORDER):
+            dict_action[name] = array_action[i]
+
+        return dict_action
+
+    def action(self, action: np.ndarray) -> OrderedDict:
+        return self.array_to_dict(action)

--- a/tests/env/test_array_action.py
+++ b/tests/env/test_array_action.py
@@ -1,0 +1,55 @@
+import glob
+
+import numpy as np
+from gym.spaces import Box
+from pynktrombonegym.env import PynkTrombone
+
+from src.env import array_action as mod
+
+cls = mod.ArrayAction
+
+sample_target_sound_file_paths = glob.glob("data/sample_target_sounds/*")
+
+
+def test_array_order():
+    order = mod.ARRAY_ORDER
+
+    order_set = set(order)
+    assert len(order_set) == len(order)
+
+    for k, v in mod.ASN.__dict__.items():
+        if not k.startswith("__"):
+            assert v in order_set
+
+
+def test__init__():
+    base_env = PynkTrombone(sample_target_sound_file_paths)
+    env = cls(base_env)
+
+    assert isinstance(env.action_space, Box)
+    assert env.action_space.shape == (len(mod.ARRAY_ORDER),)
+    assert env.action_space.dtype == np.float32
+
+    for i, name in enumerate(mod.ARRAY_ORDER):
+        np.testing.assert_allclose(base_env.action_space[name].low, env.action_space.low[i])
+
+        np.testing.assert_allclose(base_env.action_space[name].high, env.action_space.high[i])
+
+
+def test_array_to_dict():
+    base_env = PynkTrombone(sample_target_sound_file_paths)
+    env = cls(base_env)
+
+    array_action = env.action_space.sample()
+    dict_action = env.array_to_dict(array_action)
+
+    for i, name in enumerate(mod.ARRAY_ORDER):
+        np.testing.assert_allclose(dict_action[name], array_action[i])
+        assert dict_action[name].shape == (1,)
+
+
+def test_step_action():
+
+    base_env = PynkTrombone(sample_target_sound_file_paths)
+    env = cls(base_env)
+    env.step(env.action_space.sample())


### PR DESCRIPTION
## 概要
#34 PynkTromboneGym 環境クラスの辞書型で提供される行動を、一次元のnumpy配列に変換して取り扱える`ActionWrapper`クラスを作成しました。  
<!-- 変更の目的 もしくは 関連する Issue 番号 -->

## 変更内容
- ArrayAction クラスを `src/env/array_action.py`実装 
- 上記のクラスのテストコードを`tests/env/test_array_action.py`追加
- 配列にする順序を格納した`ARRAY_ORDER`を`src/env/array_action.py`についか

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲
上記以外になし。

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
