### PR TITLE
観測の声道モデル`Voc`の状態情報を配列化する観測ラッパークラスを作成しました。

### DIFF
--- a/src/env/array_voc_state.py
+++ b/src/env/array_voc_state.py
@@ -1,0 +1,84 @@
+import copy
+from collections import OrderedDict
+
+import gym
+import numpy as np
+from gym import spaces
+from pynktrombonegym.spaces import ObservationSpaceNames as OSN
+
+
+class VocStateObsNames(OSN):
+    VOC_STATE = "voc_state"
+
+
+ARRAY_ORDER = [
+    OSN.FREQUENCY,
+    OSN.PITCH_SHIFT,
+    OSN.TENSENESS,
+    OSN.CURRENT_TRACT_DIAMETERS,
+    OSN.NOSE_DIAMETERS,
+]
+
+VSON = VocStateObsNames
+
+
+class ArrayVocState(gym.ObservationWrapper):
+    """Observation Wrapper for making voc_state as array."""
+
+    def __init__(self, env: gym.Env, new_step_api: bool = False):
+        """
+        Args:
+            env (gym.Env): PynkTromboneGym Env or its wrapper.
+            voc (Voc): Vocal Tract Model class.
+            new_step_api (bool): gym api.
+        """
+        super().__init__(env, new_step_api)
+
+        self.observation_space = self.define_observation_space()
+
+    observation_space: spaces.Dict
+
+    def define_observation_space(self) -> spaces.Dict:
+        """Re-define observation space of environment."""
+        orig_space: spaces.Dict = copy.deepcopy(self.env.observation_space)
+
+        lows, highs = [], []
+        for name in ARRAY_ORDER:
+            orig_box: spaces.Box = orig_space[name]
+            lows.append(np.full(orig_box.shape, orig_box.low, dtype=orig_box.dtype))
+            highs.append(np.full(orig_box.shape, orig_box.high, dtype=orig_box.dtype))
+
+        lows = np.concatenate(lows)
+        highs = np.concatenate(highs)
+
+        box = spaces.Box(lows, highs, dtype=np.float32)
+
+        orig_space[VSON.VOC_STATE] = box
+        return orig_space
+
+    def make_voc_state_array(self, original_obs: OrderedDict) -> np.ndarray:
+        """Making `voc_state` array from original observation.
+        Args:
+            original_obs (OrderedDict): Original observation of environment.
+
+        Returns:
+            voc_state (np.ndarray): voc_state 1d array.
+        """
+        voc_state = []
+        for name in ARRAY_ORDER:
+            voc_state.append(original_obs[name])
+        voc_state = np.concatenate(voc_state)
+
+        return voc_state
+
+    def observation(self, observation: OrderedDict) -> OrderedDict:
+        """Make and add `voc_state` array to original observation.
+        Args:
+            observation (OrderedDict): Original Observation
+
+        Returns:
+            new_observation (OrderedDict): Added `voc_state`.
+        """
+        observation[VSON.VOC_STATE] = self.make_voc_state_array(observation)
+
+        return observation

--- a/tests/env/test_array_voc_state.py
+++ b/tests/env/test_array_voc_state.py
@@ -1,0 +1,86 @@
+import glob
+
+import numpy as np
+from gym.spaces import Box
+from pynktrombonegym.env import PynkTrombone
+from pynktrombonegym.spaces import ObservationSpaceNames as OSN
+
+from src.env import array_voc_state as mod
+
+cls = mod.ArrayVocState
+name_cls = mod.VocStateObsNames
+array_order = mod.ARRAY_ORDER
+sample_target_sound_file_paths = glob.glob("data/sample_target_sounds/*")
+
+
+def test_ArrayVocStateSpaceNames():
+    assert name_cls.VOC_STATE == "voc_state"
+
+
+def test_array_order():
+    order_set = set(array_order)
+    assert len(order_set) == len(array_order)
+
+    assert array_order[0] == OSN.FREQUENCY
+    assert array_order[1] == OSN.PITCH_SHIFT
+    assert array_order[2] == OSN.TENSENESS
+    assert array_order[3] == OSN.CURRENT_TRACT_DIAMETERS
+    assert array_order[4] == OSN.NOSE_DIAMETERS
+
+    assert len(array_order) == 5
+
+
+def test__init__():
+    base_env = PynkTrombone(sample_target_sound_file_paths)
+    env = cls(base_env)
+
+    start = 0
+    end = start
+
+    voc_state_box: Box = env.observation_space[name_cls.VOC_STATE]
+
+    for name in array_order:
+        orig_box: Box = base_env.observation_space[name]
+        length = orig_box.shape[0]
+        end += length
+        np.testing.assert_allclose(voc_state_box.low[start:end], orig_box.low)
+        np.testing.assert_allclose(voc_state_box.high[start:end], orig_box.high)
+
+        start += length
+
+    assert voc_state_box.shape == (end,)
+    assert voc_state_box.dtype == np.float32
+
+
+def test_make_voc_state_array():
+    base_env = PynkTrombone(sample_target_sound_file_paths)
+    env = cls(base_env)
+
+    obs = base_env.observation_space.sample()
+
+    out = env.make_voc_state_array(obs)
+
+    assert isinstance(out, np.ndarray)
+    assert out.shape == env.observation_space[name_cls.VOC_STATE].shape
+
+
+def test_observation():
+    base_env = PynkTrombone(sample_target_sound_file_paths)
+    env = cls(base_env)
+
+    obs = base_env.observation_space.sample()
+    out = env.observation(obs)
+
+    np.testing.assert_allclose(out[name_cls.VOC_STATE], env.make_voc_state_array(obs))
+
+
+def test_reset_and_step():
+    base_env = PynkTrombone(sample_target_sound_file_paths)
+    env = cls(base_env)
+
+    obs = env.reset()
+    assert name_cls.VOC_STATE in obs
+
+    action = env.action_space.sample()
+    obs, _, _, _ = env.step(action)
+    assert name_cls.VOC_STATE in obs

--- a/tests/env/test_array_voc_state.py
+++ b/tests/env/test_array_voc_state.py
@@ -13,7 +13,7 @@ array_order = mod.ARRAY_ORDER
 sample_target_sound_file_paths = glob.glob("data/sample_target_sounds/*")
 
 
-def test_ArrayVocStateSpaceNames():
+def test_name_cls():
     assert name_cls.VOC_STATE == "voc_state"
 
 


### PR DESCRIPTION
## 概要
#36 観測の声道モデル`Voc`の状態情報を配列化する観測ラッパークラスを作成しました。  
これによって、環境の観測として帰ってくる辞書に`"voc_state" : np.ndarray`が追加されます。  

<!-- 変更の目的 もしくは 関連する Issue 番号 -->

## 変更内容
- ArrayVocStateクラスを作成
- 上記のクラスのテストコードを追加
- 新たな観測クラスの名前を格納するクラス `VocStateObsNames`を作成  

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲
- 上記を実装したファイル作成
<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
