### PR TITLE
Configure replay buffer space

### DIFF
--- a/src/models/dreamer.py
+++ b/src/models/dreamer.py
@@ -120,15 +120,14 @@ class Dreamer(nn.Module):
 
         return [world_optim, con_optim]
 
-    def configure_replay_buffer(self, env: gym.Env, buffer_size: int) -> ReplayBuffer:
-        """Configure replay buffer to store experiences.
+    def configure_replay_buffer_space(self, env: gym.Env) -> dict[str, Box]:
+        """Configure replay buffer space to store experiences.
 
         Args:
             env (gym.Env): PynkTrombone environment or its wrapper class.
-            buffer_size (int): Max length of experiences you can store.
 
         Returns:
-            ReplayBuffer: Replay buffer that can store experiences.
+            spaces: Replay buffer storing spaces.
         """
         action_box = env.action_space
         vocal_state_box = env.observation_space[VSON.VOC_STATE]
@@ -141,9 +140,7 @@ class Dreamer(nn.Module):
         spaces[buffer_names.TARGET_SOUND] = generated_sound_box
         spaces[buffer_names.DONE] = Box(0, 1, shape=(1,), dtype=bool)
 
-        replay_buffer = ReplayBuffer(spaces, buffer_size)
-
-        return replay_buffer
+        return spaces
 
     @torch.no_grad()
     def collect_experiences(self, env: gym.Env, replay_buffer: ReplayBuffer) -> ReplayBuffer:

--- a/tests/models/test_dreamer.py
+++ b/tests/models/test_dreamer.py
@@ -182,10 +182,10 @@ def test_evaluation_step():
     model.tensorboard.close()
 
 
-def test_configure_replay_buffer():
+def test_configure_replay_buffer_space():
     env = AVS(AA(NAR(ABA(L1MS(target_files), action_scaler=1.0))))
     model = Dreamer(*args)
-    rb = model.configure_replay_buffer(env, bf_size)
+    rb_spaces = model.configure_replay_buffer_space(env)
     spaces = {
         buffer_names.VOC_STATE: env.observation_space[VSON.VOC_STATE],
         buffer_names.ACTION: env.action_space,
@@ -193,7 +193,7 @@ def test_configure_replay_buffer():
         buffer_names.GENERATED_SOUND: env.observation_space[VSON.GENERATED_SOUND_SPECTROGRAM],
         buffer_names.DONE: Box(0, 1, shape=(1,), dtype=bool),
     }
-    for name, box in rb.spaces.items():
+    for name, box in rb_spaces.items():
         assert box == spaces.get(name), f"space {name} isn't set properly(box:{box}"
     del env
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -13,6 +13,7 @@ from src.env.array_voc_state import VSON
 from src.env.make_env import make_env
 from src.models.dreamer import Dreamer
 from src.trainer import Trainer
+from src.datamodules.replay_buffer import ReplayBuffer
 
 # from src.models.components.agent import Agent # AgentのPRがマージされたら追加
 from tests.models.abc.dummy_classes import DummyAgent as Agent
@@ -107,7 +108,8 @@ def test_fit(device):
         ckpt_destination, tb, device=device, collect_experience_interval=2, chunk_size=2
     )
     dreamer = Dreamer(*dreamer_args, imagination_horizon=1)
-    rb = dreamer.configure_replay_buffer(env, buffer_size=4)
+    rb_spaces = dreamer.configure_replay_buffer_space(env)
+    rb = ReplayBuffer(rb_spaces, buffer_size=4)
     trainer.setup_model_attribute(dreamer)
     trainer.fit(env, rb, dreamer)
     del env


### PR DESCRIPTION
## 概要
Dreamerの`configure_replay_buffer(env, buffer_size) -> ReplayBuffer`を`configure_replay_buffer_space(env) -> dict[str, Box]`に修正しました。ReplayBufferはhydraによって部分的にinstantiateされる仕様を想定しているためです。これにより、機能の直行性が向上します。

<!-- 変更の目的 もしくは 関連する Issue 番号 -->

## 変更内容
- Dreamerの`configure_replay_buffer(env, buffer_size) -> ReplayBuffer`を`configure_replay_buffer_space(env) -> dict[str, Box]`に修正
- test_dreamerを機能変更に伴って修正
- test_trainerを機能変更に伴って修正

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲
- test_dreamer.py
- test_trainer.py
<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [ ] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
