### PR TITLE
#56 voc stateの再構築追加

### DIFF
--- a/src/models/components/observation_auto_encoder.py
+++ b/src/models/components/observation_auto_encoder.py
@@ -82,6 +82,7 @@ class ObservationDecoder(AbsObservationDecoder):
     def __init__(
         self,
         decoder: ConformerDecoder,
+        voc_state_size:int,
         feats_T: int,
         conv_kernel_size: int = 3,
         conv_padding_size: int = 1,
@@ -102,6 +103,11 @@ class ObservationDecoder(AbsObservationDecoder):
             kernel_size=conv_kernel_size,
             padding=conv_padding_size,
             bias=conv_bias,
+        )
+
+        self.voc_decoder = torch.nn.Linear(
+            self.decoder.idim,
+            voc_state_size
         )
 
     def forward(
@@ -126,6 +132,10 @@ class ObservationDecoder(AbsObservationDecoder):
 
         decoder_input = time_extend_input.transpose(1, 2)  # (batch, channels, feats_T)
 
-        reconst_obs = self.decoder(torch.tanh(decoder_input))
+        reconst_mel = self.decoder(torch.tanh(decoder_input))
+
+        reconst_voc = self.voc_decoder(concat_input)
+
+        reconst_obs = (reconst_mel, reconst_voc)
 
         return reconst_obs

--- a/src/models/components/observation_auto_encoder.py
+++ b/src/models/components/observation_auto_encoder.py
@@ -87,7 +87,7 @@ class ObservationDecoder(AbsObservationDecoder):
         conv_kernel_size: int = 3,
         conv_padding_size: int = 1,
         conv_bias: bool = True,
-    ):
+    ) -> None:
         """
         Args:
             decoder: Decoder to reconstruct the mel spectrogram
@@ -111,15 +111,15 @@ class ObservationDecoder(AbsObservationDecoder):
         self,
         hidden: torch.Tensor,
         state: torch.Tensor,
-    ):
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Decode to observation.
 
         Args:
             hidden (Tensor): hidden state `h_t`.
             state (Tensor): world state `s_t`.
         Returns:
-            obs (Tensor): reconstructed observation (o^_t).
-                For instance, obs=(voc state v_t, generated sound g_t) is returned.
+            obs (tuple[Tensor, Tensor]): reconstructed observation (o^_t).
+                obs=(voc state v_t, generated sound g_t) is returned.
         """
         concat_input = torch.concat((hidden, state), dim=1)
 

--- a/src/models/components/observation_auto_encoder.py
+++ b/src/models/components/observation_auto_encoder.py
@@ -82,7 +82,7 @@ class ObservationDecoder(AbsObservationDecoder):
     def __init__(
         self,
         decoder: ConformerDecoder,
-        voc_state_size:int,
+        voc_state_size: int,
         feats_T: int,
         conv_kernel_size: int = 3,
         conv_padding_size: int = 1,
@@ -105,10 +105,7 @@ class ObservationDecoder(AbsObservationDecoder):
             bias=conv_bias,
         )
 
-        self.voc_decoder = torch.nn.Linear(
-            self.decoder.idim,
-            voc_state_size
-        )
+        self.voc_decoder = torch.nn.Linear(self.decoder.idim, voc_state_size)
 
     def forward(
         self,

--- a/tests/models/components/test_observation_auto_encoder.py
+++ b/tests/models/components/test_observation_auto_encoder.py
@@ -68,9 +68,7 @@ def test_observation_decoder(
 
     # instance observation encoder
     obs_decoder = ObservationDecoder(
-        decoder=conformer_decoder,
-        feats_T=feats_T,
-        voc_state_size=v_channels
+        decoder=conformer_decoder, feats_T=feats_T, voc_state_size=v_channels
     )
 
     # create input
@@ -86,4 +84,3 @@ def test_observation_decoder(
 
     assert _mel.size() == torch.Size([batch_size, mel_channels, feats_T])
     assert _voc.size() == torch.Size([batch_size, v_channels])
-

--- a/tests/models/components/test_observation_auto_encoder.py
+++ b/tests/models/components/test_observation_auto_encoder.py
@@ -18,7 +18,7 @@ from src.models.components.posterior_encoder_vits import PosteriorEncoderVITS
     mel_channels,
     feats_T
     """,
-    [(1, 192, 192, 44, 80, 5)],
+    [(1, 192, 192, 75, 80, 5)],
 )
 def test_observation_encoder(
     batch_size: int, hidden_size: int, state_size: int, v_channels: int, mel_channels: int, feats_T
@@ -57,7 +57,7 @@ def test_observation_encoder(
     mel_channels,
     feats_T
     """,
-    [(1, 192, 192, 44, 80, 5)],
+    [(1, 192, 192, 75, 80, 5)],
 )
 def test_observation_decoder(
     batch_size: int, hidden_size: int, state_size: int, v_channels: int, mel_channels: int, feats_T
@@ -70,6 +70,7 @@ def test_observation_decoder(
     obs_decoder = ObservationDecoder(
         decoder=conformer_decoder,
         feats_T=feats_T,
+        voc_state_size=v_channels
     )
 
     # create input
@@ -81,4 +82,8 @@ def test_observation_decoder(
         state,
     )
 
-    assert reconst_obs.size() == torch.Size([batch_size, mel_channels, feats_T])
+    _mel, _voc = reconst_obs
+
+    assert _mel.size() == torch.Size([batch_size, mel_channels, feats_T])
+    assert _voc.size() == torch.Size([batch_size, v_channels])
+


### PR DESCRIPTION
## 概要
voc state decoderの追加

## 変更内容
とりあえずLinear一層のvoc_decoderを追加
- src/models/components/observation_auto_encoder.py
- tests/models/components/test_observation_auto_encoder.py
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足
Linear一層なので再構築できるのか疑問
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
