### PR TITLE
実験を放置するために`screen`パッケージを依存関係に追加しました。  

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
   ffmpeg \
   git \
   make \
+  screen \
   unzip \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## 概要  
[screenパッケージを使用することで走らせたコードを放置したうえで、再開することができるようになります](https://linuxjm.osdn.jp/html/GNU_screen/man1/screen.1.html)    

### 使い方  
- `screen python src/train.py`でsshなどの接続が切れても動き続ける 
- `screen -ls`でセッションを確認する  
    e.g. 
    ```
    There are screens on:
        2947.a_bsc      (Detached)
        17657.b_test1   (Detached)
        17897.c_test2   (Detached)
    ```
- `screen -r <id>`で再接続。 e.g. `screen -r 2947`   

<!-- 変更の目的 もしくは 関連する Issue 番号 -->

## 変更内容
Dockerfileを編集

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 参考  
https://qiita.com/hnishi/items/3190f2901f88e2594a5f

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
