### PR TITLE
ADD configuration `default_frequency`

### DIFF
--- a/src/env/make_env.py
+++ b/src/env/make_env.py
@@ -19,6 +19,7 @@ def make_env(
     sample_rate: int = 44100,
     n_mels: int = 80,
     dtype: Any = np.float32,
+    default_frequency: float = 400.0,
 ) -> gym.Env:
     """Creates an wrapped environment instance from a list of audio dir paths.
 
@@ -31,13 +32,20 @@ def make_env(
         sample_rate (int): The sample rate of audio files. Default is 44100.
         n_mels (int): The number of mel bands to generate. Default is 80.
         dtype (Any): The data type of the audio. Default is np.float32.
+        default_frequency (float): Default vocal tract frequency.
 
     Returns:
         gym.Env: The created environment instance.
     """
     files = create_file_list(dataset_dirs, file_exts)
 
-    base_env = Log1pMelSpectrogram(files, sample_rate=sample_rate, n_mels=n_mels, dtype=dtype)
+    base_env = Log1pMelSpectrogram(
+        files,
+        sample_rate=sample_rate,
+        n_mels=n_mels,
+        dtype=dtype,
+        default_frequency=default_frequency,
+    )
 
     if action_scaler is None:
         action_scaler = base_env.generate_chunk / base_env.sample_rate

--- a/tests/env/test_make_env.py
+++ b/tests/env/test_make_env.py
@@ -17,6 +17,7 @@ def test__init__():
         "action_scaler": 1.0,
         "low": -10.0,
         "high": 10.0,
+        "default_frequency": 300.0,
     }
     env = mod.make_env(**configs)
     assert isinstance(env, gym.Env)


### PR DESCRIPTION
## 概要
make_env実行時に声道モデルの標準周波数を設定可能にしました。  
<!-- 変更の目的 もしくは 関連する Issue 番号 -->

## 変更内容
- make_envの引数に`default_frequency`を追加し、base_envをインスタンス化するときに指定するようにしました。  
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
