### PR TITLE
make_env関数を修正し、LogMelSpectrogram観測ラッパーを適用しました。  

### DIFF
--- a/src/env/log_mel_spectrogram.py
+++ b/src/env/log_mel_spectrogram.py
@@ -38,7 +38,7 @@ class LogMelSpectrogram(gym.ObservationWrapper):
         self.n_fft = n_fft
         self.n_mels = n_mels
         self.log_offset = log_offset
-        self.mel_filter_banck = librosa.filters.mel(
+        self.mel_filter_bank = librosa.filters.mel(
             sr=sample_rate, n_fft=n_fft, n_mels=n_mels, dtype=dtype
         )
 
@@ -85,4 +85,4 @@ class LogMelSpectrogram(gym.ObservationWrapper):
             log mel spectrogram (np.ndarray): log mel spectrogram
         """
 
-        return np.log(np.matmul(self.mel_filter_banck, spectrogram) + self.log_offset)
+        return np.log(np.matmul(self.mel_filter_bank, spectrogram) + self.log_offset)

--- a/src/env/log_mel_spectrogram.py
+++ b/src/env/log_mel_spectrogram.py
@@ -1,0 +1,88 @@
+import copy
+from collections import OrderedDict
+from typing import Any
+
+import gym
+import librosa
+import numpy as np
+from gym import spaces
+from pynktrombonegym.spaces import ObservationSpaceNames as OSN
+
+
+class LogMelSpectrogram(gym.ObservationWrapper):
+    """Observation Wrapper for converting spectrogram to log mel scale."""
+
+    def __init__(
+        self,
+        env: gym.Env,
+        sample_rate: float,
+        n_fft: int,
+        n_mels: int = 80,
+        log_offset: float = 1e-6,
+        dtype: Any = np.float32,
+        new_step_api: bool = True,
+    ) -> None:
+        """
+        Args:
+            env (gym.Env): PynkTromboneGym Env.
+            sample_rate (int): Sampling rate of wave.
+            n_fft (int): STFT window size.
+            n_mels (int): The size of mel channels.
+            log_offset (float): Minimum amplitude of spectrogram to avoid -inf.
+            dtype (Any): Mel filter bank data type.
+            new_step_api (bool): gym api.
+        """
+        super().__init__(env, new_step_api)
+
+        self.sample_rate = sample_rate
+        self.n_fft = n_fft
+        self.n_mels = n_mels
+        self.log_offset = log_offset
+        self.mel_filter_banck = librosa.filters.mel(
+            sr=sample_rate, n_fft=n_fft, n_mels=n_mels, dtype=dtype
+        )
+
+        self.observation_space = self.define_observation_space()
+
+    observation_space: spaces.Dict
+
+    def define_observation_space(self) -> spaces.Dict:
+        """Convert base observation spectrogram to mel spectrogram."""
+
+        base_obs_space = self.env.observation_space
+        obs_space = copy.deepcopy(base_obs_space)
+
+        spect_space: spaces.Box = base_obs_space[OSN.TARGET_SOUND_SPECTROGRAM]
+        shape = (self.n_mels, spect_space.shape[-1])
+
+        log_mel_space = spaces.Box(-np.inf, np.inf, shape)
+
+        obs_space[OSN.TARGET_SOUND_SPECTROGRAM] = log_mel_space
+        obs_space[OSN.GENERATED_SOUND_SPECTROGRAM] = log_mel_space
+
+        return obs_space
+
+    def observation(
+        self, observation: OrderedDict[str, np.ndarray]
+    ) -> OrderedDict[str, np.ndarray]:
+        generated_spect = observation[OSN.GENERATED_SOUND_SPECTROGRAM]
+        target_spect = observation[OSN.TARGET_SOUND_SPECTROGRAM]
+
+        generated_log_mel = self.log_mel(generated_spect)
+        target_log_mel = self.log_mel(target_spect)
+
+        observation[OSN.GENERATED_SOUND_SPECTROGRAM] = generated_log_mel
+        observation[OSN.TARGET_SOUND_SPECTROGRAM] = target_log_mel
+
+        return observation
+
+    def log_mel(self, spectrogram: np.ndarray) -> np.ndarray:
+        """Apply log mel conversion.
+        Args:
+            spectrogram (np.ndarray): source spectrogram
+
+        Returns:
+            log mel spectrogram (np.ndarray): log mel spectrogram
+        """
+
+        return np.log(np.matmul(self.mel_filter_banck, spectrogram) + self.log_offset)

--- a/tests/env/test_log_mel_spectrogram.py
+++ b/tests/env/test_log_mel_spectrogram.py
@@ -89,3 +89,12 @@ def test_log_mel():
     np.testing.assert_allclose(zero_logmel, np.log(1e-6))
 
     del env
+
+
+def test_reset_and_step():
+    env = PynkTrombone(SAMPLE_TARGET_SOUND_FILE_PATHS)
+    wrapper = LogMelSpectrogram(env, env.sample_rate, env.stft_window_size)
+    wrapper.reset()
+
+    action = env.action_space.sample()
+    env.step(action)

--- a/tests/env/test_log_mel_spectrogram.py
+++ b/tests/env/test_log_mel_spectrogram.py
@@ -7,42 +7,39 @@ from pynktrombonegym.env import PynkTrombone
 from pynktrombonegym.spaces import ObservationSpaceNames as OSN
 from pynktrombonegym.spectrogram import calc_rfft_channel_num
 
-from src.env import log_mel_spectrogram as mod
+from src.env.log_mel_spectrogram import LogMelSpectrogram
 
-cls = mod.LogMelSpectrogram
-
-sample_target_sound_file_paths = glob.glob("data/sample_target_sounds/*")
+SAMPLE_TARGET_SOUND_FILE_PATHS = glob.glob("data/sample_target_sounds/*")
 
 
 def test__init__():
-    base_env = PynkTrombone(sample_target_sound_file_paths)
+    base_env = PynkTrombone(SAMPLE_TARGET_SOUND_FILE_PATHS)
     n_mels = 80
     log_offset = 1e-6
     n_fft = base_env.stft_window_size
     dtype = np.float32
     fft_c = calc_rfft_channel_num(n_fft)
     filter_bank_shape = (n_mels, fft_c)
-    wrapper = cls(
+    wrapper = LogMelSpectrogram(
         base_env, base_env.sample_rate, base_env.stft_window_size, n_mels, log_offset, dtype
     )
-
     assert wrapper.sample_rate == base_env.sample_rate
     assert wrapper.n_fft == n_fft
     assert wrapper.n_mels == n_mels
     assert wrapper.log_offset == log_offset
-    assert wrapper.mel_filter_banck.shape == filter_bank_shape
-    assert wrapper.mel_filter_banck.dtype == dtype
+    assert wrapper.mel_filter_bank.shape == filter_bank_shape
+    assert wrapper.mel_filter_bank.dtype == dtype
 
     del base_env
 
 
 def test_define_observation_space():
-    base_env = PynkTrombone(sample_target_sound_file_paths)
+    base_env = PynkTrombone(SAMPLE_TARGET_SOUND_FILE_PATHS)
     sample_rate = base_env.sample_rate
     n_fft = base_env.stft_window_size
     n_mels = 80
     spect_len = base_env.observation_space[OSN.TARGET_SOUND_SPECTROGRAM].shape[1]
-    observation_wrapper = cls(base_env, sample_rate, n_fft, n_mels)
+    observation_wrapper = LogMelSpectrogram(base_env, sample_rate, n_fft, n_mels)
 
     obs_space = observation_wrapper.define_observation_space()
 
@@ -56,11 +53,11 @@ def test_define_observation_space():
 
 
 def test_observation():
-    env = PynkTrombone(sample_target_sound_file_paths)
+    env = PynkTrombone(SAMPLE_TARGET_SOUND_FILE_PATHS)
     sample_rate = env.sample_rate
     n_fft = env.stft_window_size
     n_mels = 80
-    log_mel_spectrogram = cls(env, sample_rate, n_fft, n_mels)
+    log_mel_spectrogram = LogMelSpectrogram(env, sample_rate, n_fft, n_mels)
     shape = log_mel_spectrogram.observation_space[OSN.TARGET_SOUND_SPECTROGRAM].shape
 
     obs = env.reset()
@@ -76,16 +73,16 @@ def test_observation():
 
 
 def test_log_mel():
-    env = PynkTrombone(sample_target_sound_file_paths)
+    env = PynkTrombone(SAMPLE_TARGET_SOUND_FILE_PATHS)
     sample_rate = env.sample_rate
     n_mels = 80
     n_fft = env.stft_window_size
-    log_mel_spectrogram = cls(env, sample_rate, n_fft, n_mels)
-    shape = env.observation_space[OSN.TARGET_SOUND_SPECTROGRAM].shape
-    logmel_shape = (n_mels, shape[1])
-    zero_spect = np.zeros(shape)
+    log_mel_spectrogram = LogMelSpectrogram(env, sample_rate, n_fft, n_mels)
+    target_spectrogram_shape = env.observation_space[OSN.TARGET_SOUND_SPECTROGRAM].shape
+    logmel_shape = (n_mels, target_spectrogram_shape[1])
+    zero_spectrogram = np.zeros(target_spectrogram_shape)
 
-    zero_logmel = log_mel_spectrogram.log_mel(zero_spect)
+    zero_logmel = log_mel_spectrogram.log_mel(zero_spectrogram)
 
     assert isinstance(zero_logmel, np.ndarray)
     assert zero_logmel.shape == logmel_shape

--- a/tests/env/test_log_mel_spectrogram.py
+++ b/tests/env/test_log_mel_spectrogram.py
@@ -1,0 +1,94 @@
+import glob
+from collections import OrderedDict
+
+import numpy as np
+from gym import spaces
+from pynktrombonegym.env import PynkTrombone
+from pynktrombonegym.spaces import ObservationSpaceNames as OSN
+from pynktrombonegym.spectrogram import calc_rfft_channel_num
+
+from src.env import log_mel_spectrogram as mod
+
+cls = mod.LogMelSpectrogram
+
+sample_target_sound_file_paths = glob.glob("data/sample_target_sounds/*")
+
+
+def test__init__():
+    base_env = PynkTrombone(sample_target_sound_file_paths)
+    n_mels = 80
+    log_offset = 1e-6
+    n_fft = base_env.stft_window_size
+    dtype = np.float32
+    fft_c = calc_rfft_channel_num(n_fft)
+    filter_bank_shape = (n_mels, fft_c)
+    wrapper = cls(
+        base_env, base_env.sample_rate, base_env.stft_window_size, n_mels, log_offset, dtype
+    )
+
+    assert wrapper.sample_rate == base_env.sample_rate
+    assert wrapper.n_fft == n_fft
+    assert wrapper.n_mels == n_mels
+    assert wrapper.log_offset == log_offset
+    assert wrapper.mel_filter_banck.shape == filter_bank_shape
+    assert wrapper.mel_filter_banck.dtype == dtype
+
+    del base_env
+
+
+def test_define_observation_space():
+    base_env = PynkTrombone(sample_target_sound_file_paths)
+    sample_rate = base_env.sample_rate
+    n_fft = base_env.stft_window_size
+    n_mels = 80
+    spect_len = base_env.observation_space[OSN.TARGET_SOUND_SPECTROGRAM].shape[1]
+    observation_wrapper = cls(base_env, sample_rate, n_fft, n_mels)
+
+    obs_space = observation_wrapper.define_observation_space()
+
+    assert isinstance(obs_space, spaces.Dict)
+    assert isinstance(obs_space[OSN.TARGET_SOUND_SPECTROGRAM], spaces.Box)
+    assert isinstance(obs_space[OSN.GENERATED_SOUND_SPECTROGRAM], spaces.Box)
+    assert obs_space[OSN.TARGET_SOUND_SPECTROGRAM].shape == (n_mels, spect_len)
+    assert obs_space[OSN.GENERATED_SOUND_SPECTROGRAM].shape == (n_mels, spect_len)
+
+    del base_env
+
+
+def test_observation():
+    env = PynkTrombone(sample_target_sound_file_paths)
+    sample_rate = env.sample_rate
+    n_fft = env.stft_window_size
+    n_mels = 80
+    log_mel_spectrogram = cls(env, sample_rate, n_fft, n_mels)
+    shape = log_mel_spectrogram.observation_space[OSN.TARGET_SOUND_SPECTROGRAM].shape
+
+    obs = env.reset()
+    obs = log_mel_spectrogram.observation(obs)
+
+    assert isinstance(obs, OrderedDict)
+    assert isinstance(obs[OSN.TARGET_SOUND_SPECTROGRAM], np.ndarray)
+    assert isinstance(obs[OSN.GENERATED_SOUND_SPECTROGRAM], np.ndarray)
+    assert obs[OSN.TARGET_SOUND_SPECTROGRAM].shape == shape
+    assert obs[OSN.GENERATED_SOUND_SPECTROGRAM].shape == shape
+
+    del env
+
+
+def test_log_mel():
+    env = PynkTrombone(sample_target_sound_file_paths)
+    sample_rate = env.sample_rate
+    n_mels = 80
+    n_fft = env.stft_window_size
+    log_mel_spectrogram = cls(env, sample_rate, n_fft, n_mels)
+    shape = env.observation_space[OSN.TARGET_SOUND_SPECTROGRAM].shape
+    logmel_shape = (n_mels, shape[1])
+    zero_spect = np.zeros(shape)
+
+    zero_logmel = log_mel_spectrogram.log_mel(zero_spect)
+
+    assert isinstance(zero_logmel, np.ndarray)
+    assert zero_logmel.shape == logmel_shape
+    np.testing.assert_allclose(zero_logmel, np.log(1e-6))
+
+    del env

--- a/tests/env/test_make_env.py
+++ b/tests/env/test_make_env.py
@@ -69,12 +69,3 @@ def test_create_file_list():
     assert mod.create_file_list(sample_target_sound_dir_paths, [".wav"]) == glob.glob(
         "data/sample_target_sounds/*.wav", recursive=False
     )
-
-
-def test_apply_wrappers():
-    base_env = Log1pMelSpectrogram(sample_target_sound_file_paths)
-    action_scaler = base_env.generate_chunk / base_env.sample_rate
-    low = -10.0
-    high = 10.0
-    env = mod.apply_wrappers(base_env, action_scaler, low, high)
-    assert isinstance(env, gym.Env)


### PR DESCRIPTION
## 概要
#98 
<!-- 変更の目的 もしくは 関連する Issue 番号 -->

## 変更内容
- make_env関数を修正

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲
対数メル周波数スペクトログラムの値域が [log(1e-6) ~ -13, inf]に変わりました。再構成誤差が大きく変化する恐れがあります。 
<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
