### PR TITLE
2023/02/14 から行っていたMFCC損失を組み込んだ実験による変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,11 @@ docker-run:
         --gpus all \
         --mount type=volume,source=speech-generation,target=/workspace \
         speech-generation:latest
+
+docker-run-mount:
+	docker run -it \
+        --gpus all \
+        --mount type=volume,source=speech-generation,target=/workspace \
+		--mount type=bind,source=$(pwd)/data,target=/workspace/data \
+		--mount type=bind,source=$(pwd)/logs,target=/workspace/logs \
+        speech-generation:latest

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,6 @@ docker-run-mount:
 	docker run -it \
         --gpus all \
         --mount type=volume,source=speech-generation,target=/workspace \
-		--mount type=bind,source=$(pwd)/data,target=/workspace/data \
-		--mount type=bind,source=$(pwd)/logs,target=/workspace/logs \
+		--mount type=bind,source="${PWD}/data",target=/workspace/data \
+		--mount type=bind,source="${PWD}/logs",target=/workspace/logs \
         speech-generation:latest

--- a/configs/experiment/mfcc_loss.yaml
+++ b/configs/experiment/mfcc_loss.yaml
@@ -1,0 +1,42 @@
+# @package _global_
+
+# to execute this experiment run:
+# python train.py experiment=example
+
+defaults:
+  - override /env: make_env.yaml
+  - override /model: linear_stackings.yaml
+  - override /replay_buffer: replay_buffer.yaml
+  - override /trainer: trainer.yaml
+
+# all parameters below will be merged with parameters from default configurations set above
+# this allows you to overwrite only specified parameters
+
+task_name: apply-mfcc-loss
+
+tags: ["interval 50", "buf size 2M", "Collect 8K", "mfcc loss"]
+
+replay_buffer:
+  buffer_size: 2_000_000
+
+model:
+  agent:
+    action_noise_ratio: 0.8
+  world_optimizer:
+    lr: 0.001
+  controller_optimizer:
+    lr: 0.001
+  free_nats: 3.0
+  num_collect_experience_steps: 8000
+
+  coef_mfcc_loss: 1.0
+  coef_spectrogram_loss: 0.01
+  n_mfcc: 40
+  n_mels: ${env.n_mels}
+  mfcc_lifter_size: 12
+
+trainer:
+  num_episode: 500
+  batch_size: 64
+  evaluation_interval: 50
+  model_save_interval: 50

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
 torchvision = "^0.14.1"
-torchaudio = "^0.13.1"
+torchaudio = {url = "https://download.pytorch.org/whl/cu116/torchaudio-0.13.1%2Bcu116-cp310-cp310-linux_x86_64.whl"}
 pynktrombonegym = {git = "https://github.com/matsuo-group24-PinkTrombone/PynkTromboneGym.git", rev = "master"}
 humanfriendly = "^10.0"
 typeguard = "^2.13.3"

--- a/src/models/dreamer.py
+++ b/src/models/dreamer.py
@@ -535,7 +535,7 @@ class Dreamer(nn.Module):
             self.agent,
             env,
             self.tensorboard,
-            prefix + "target-generatino-imagination-spectrograms",
+            prefix + "target-generation-imagination-spectrograms",
             self.current_step,
             device=self.device,
             dtype=self.dtype,

--- a/src/models/dreamer.py
+++ b/src/models/dreamer.py
@@ -7,12 +7,12 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import torchaudio.functional as audioF
 from gym.spaces import Box
 from torch import Tensor
 from torch.distributions import kl_divergence
 from torch.optim import Optimizer
 from torch.utils.tensorboard import SummaryWriter
-import torchaudio.functional as audioF
 
 from ..datamodules import buffer_names
 from ..datamodules.replay_buffer import ReplayBuffer
@@ -123,7 +123,7 @@ class Dreamer(nn.Module):
         self.mfcc_lifter_size = mfcc_lifter_size
 
         self.dct_mat: Tensor
-        self.register_buffer("dct_mat",audioF.create_dct(n_mfcc, n_mels, mfcc_dct_norm), False)
+        self.register_buffer("dct_mat", audioF.create_dct(n_mfcc, n_mels, mfcc_dct_norm), False)
 
     def configure_optimizers(self) -> tuple[Optimizer, Optimizer]:
         """Configure world optimizer and controller optimizer.

--- a/src/models/dreamer.py
+++ b/src/models/dreamer.py
@@ -3,6 +3,7 @@ from functools import partial
 from typing import Any, Optional
 
 import gym
+import matplotlib.pyplot as plt
 import numpy as np
 import torch
 import torch.nn as nn
@@ -18,6 +19,7 @@ from ..datamodules import buffer_names
 from ..datamodules.replay_buffer import ReplayBuffer
 from ..env.array_voc_state import VocStateObsNames as ObsNames
 from ..env.array_voc_state import VocStateObsNames as VSON
+from ..utils.visualize import visualize_model_approximation
 from .abc.agent import Agent
 from .abc.controller import Controller
 from .abc.observation_auto_encoder import ObservationDecoder, ObservationEncoder
@@ -527,6 +529,17 @@ class Dreamer(nn.Module):
             "target_generated_mse": target_generated_mse,
             "target_generated_mae": target_generated_mae,
         }
+
+        visualize_model_approximation(
+            self.world,
+            self.agent,
+            env,
+            self.tensorboard,
+            prefix + "target-generatino-imagination-spectrograms",
+            self.current_step,
+            device=self.device,
+            dtype=self.dtype,
+        )
 
         return loss_dict
 

--- a/src/models/dreamer.py
+++ b/src/models/dreamer.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from functools import partial
-from typing import Any
+from typing import Any, Optional
 
 import gym
 import numpy as np
@@ -12,6 +12,7 @@ from torch import Tensor
 from torch.distributions import kl_divergence
 from torch.optim import Optimizer
 from torch.utils.tensorboard import SummaryWriter
+import torchaudio.functional as audioF
 
 from ..datamodules import buffer_names
 from ..datamodules.replay_buffer import ReplayBuffer
@@ -55,6 +56,11 @@ class Dreamer(nn.Module):
         sample_rate: int = 44100,
         coef_spectrogram_loss: float = 1.0,
         coef_latent_space_loss: float = 0.0,
+        coef_mfcc_loss: float = 0.0,
+        n_mfcc: int = 40,
+        n_mels: int = 80,
+        mfcc_dct_norm: Optional[str] = "ortho",
+        mfcc_lifter_size: int = 12,
     ) -> None:
         """
         Args:
@@ -77,6 +83,12 @@ class Dreamer(nn.Module):
             coef_spectrogram_loss (float): Coefficient for loss between target and generated spectrogram. (default 1.0).
             coef_latent_space_loss (float): Coefficient for loss on latent space between target and generated.
                 Default value is 0.0 for backward compatibility.
+            coef_mfcc_loss (float): Coefficient for loss between target and generated mfcc.
+                Default value is 0.0 for backward compatibility.
+            n_mfcc (int): MFCC channels size.
+            n_mels (int): Mel Spectrogram channel size.
+            mfcc_dct_norm (Optional[str]): Following to torchaudio MFCC implementation.
+            mfcc_lifter_size (int): Low path filter for mfcc loss
         """
 
         super().__init__()
@@ -107,6 +119,11 @@ class Dreamer(nn.Module):
         self.sample_rate = sample_rate
         self.coef_spectrogram_loss = coef_spectrogram_loss
         self.coef_latent_space_loss = coef_latent_space_loss
+        self.coef_mfcc_loss = coef_mfcc_loss
+        self.mfcc_lifter_size = mfcc_lifter_size
+
+        self.dct_mat: Tensor
+        self.register_buffer("dct_mat",audioF.create_dct(n_mfcc, n_mels, mfcc_dct_norm), False)
 
     def configure_optimizers(self) -> tuple[Optimizer, Optimizer]:
         """Configure world optimizer and controller optimizer.
@@ -347,6 +364,7 @@ class Dreamer(nn.Module):
 
         latent_space_loss = 0.0
         spectrogram_loss = 0.0
+        mfcc_loss = 0.0
         for horizon in range(self.imagination_horizon):
             indices = start_indices + horizon
             target = torch.as_tensor(
@@ -370,6 +388,16 @@ class Dreamer(nn.Module):
 
             latent_space_loss += F.mse_loss(target_latent, rec_generated_latent)
 
+            # MFCC loss
+            # shape: (B, C, L) -> (B, L, C) -> (C, L, B)
+            target_mfcc = (target.transpose(-1, -2) @ self.dct_mat).transpose(-1, 0)[
+                : self.mfcc_lifter_size
+            ]
+            rec_gened_mfcc = (rec_gened_sound.transpose(-1, -2) @ self.dct_mat).transpose(-1, 0)[
+                : self.mfcc_lifter_size
+            ]
+            mfcc_loss += F.mse_loss(target_mfcc, rec_gened_mfcc)
+
             hidden = next_hidden
 
             is_done = dones[indices, batch_arange].reshape(-1)
@@ -391,21 +419,26 @@ class Dreamer(nn.Module):
 
         latent_space_loss /= self.imagination_horizon
         spectrogram_loss /= self.imagination_horizon
+        mfcc_loss /= self.imagination_horizon
+
         loss = (
             self.coef_spectrogram_loss * spectrogram_loss
             + self.coef_latent_space_loss * latent_space_loss
+            + self.coef_mfcc_loss * mfcc_loss
         )
 
         loss_dict = {
             "loss": loss,
             "spectrogram_loss": spectrogram_loss,
             "latent_space_loss": latent_space_loss,
+            "mfcc_loss": mfcc_loss,
         }
 
         prefix = "controller_training_step/"
         self.log(prefix + "loss", loss)
         self.log(prefix + "spectrogram_loss", loss)
         self.log(prefix + "latent_space_loss", latent_space_loss)
+        self.log(prefix + "mfcc_loss", mfcc_loss)
 
         return loss_dict, experiences
 

--- a/src/utils/visualize.py
+++ b/src/utils/visualize.py
@@ -1,0 +1,108 @@
+import gym
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from librosa.feature import melspectrogram
+from torch.utils.tensorboard import SummaryWriter
+
+from ..env.array_voc_state import VocStateObsNames as ObsNames
+from ..models.abc.agent import Agent
+from ..models.abc.world import World
+
+
+def make_spectrogram_figure(
+    target: np.ndarray,
+    generated: np.ndarray,
+    predicted_generated: np.ndarray,
+) -> None:
+    fig, axes = plt.subplots(3, 1)
+    fig.tight_layout()
+    labels = {"xlabel": "timestamp", "ylabel": "Hz"}
+
+    data = {
+        "Target": target,
+        "Generated": generated,
+        "Predicted Generated": predicted_generated,
+    }
+    # show target mel spectrogram
+    for i, (title, spect) in enumerate(data.items()):
+        mappable = axes[i].imshow(spect, aspect="auto")
+        axes[i].set(**labels, title=title)
+        fig.colorbar(mappable, ax=axes[i])
+
+    return fig
+
+
+@torch.no_grad()
+def visualize_model_approximation(
+    world: World,
+    agent: Agent,
+    env: gym.Env,
+    tensorboard: SummaryWriter,
+    tag: str,
+    global_step: int,
+    visualize_per_episode: bool = True,
+    visualize_steps: int = None,
+    dtype: torch.dtype = torch.float32,
+    device: str = "cpu",
+) -> None:
+    """
+    Args:
+        world_model (torch.nn.Module): model that need to be checked
+        env (gym.env): gym.env or it's wrapper class
+        tensorboard(SummaryWriter): visualized figures is stored to this tensorboard
+        visualize_per_episode(bool): you can select whether to visualize one episode or a fixed number of steps.
+    Returns:
+        None
+    """
+    all_target = []
+    all_generated_ref = []
+    all_generated_pred = []
+    obs = env.reset()
+
+    target_np = obs[ObsNames.TARGET_SOUND_SPECTROGRAM]
+    voc_state_np = obs[ObsNames.VOC_STATE]
+    generated_np = obs[ObsNames.GENERATED_SOUND_SPECTROGRAM]
+
+    target = torch.as_tensor(target_np, dtype=dtype, device=device)  # t_1
+    voc_state = torch.as_tensor(voc_state_np, dtype=dtype, device=device)  # v_0
+    generated_ref = torch.as_tensor(generated_np, dtype=dtype, device=device)  # g_0
+
+    state = torch.zeros(world.prior.state_shape, dtype=dtype, device=device)  # s_0
+
+    # init hidden for world model's prediction
+    agent.reset()
+    hidden = agent.hidden  # h_0
+
+    done = False
+    while not done:
+        all_target.append(target)  # T_t+1
+
+        # append prediction by world model
+        action = agent.act(
+            obs=(voc_state, generated_ref), target=target, probabilistic=False
+        )  # a_t
+        hidden = world.transition(hidden, state, action)  # h_t+1
+        state = world.prior(hidden).sample()  # s_t+1
+        _, generated_pred = world.obs_decoder(hidden, state)  # g_t+1(pred)
+        all_generated_pred.append(generated_pred.cpu().numpy())
+
+        # append generated from env
+        obs, _, done, _ = env.step(action.squeeze(0).cpu().numpy())  # o_t+1
+
+        all_generated_ref.append(obs[ObsNames.GENERATED_SOUND_SPECTROGRAM])
+
+        generated_ref_np = obs[ObsNames.GENERATED_SOUND_SPECTROGRAM]  # g_t+1(ref)
+        voc_state_np = obs[ObsNames.VOC_STATE]
+        target_np = obs[ObsNames.TARGET_SOUND_SPECTROGRAM]  # T_t+2
+
+        generated_ref = torch.as_tensor(generated_ref_np, dtype=dtype, device=device)
+        target = torch.as_tensor(target_np, dtype=dtype, device=device)
+        voc_state = torch.as_tensor(voc_state_np, dtype=dtype, device=device)
+
+    target_spect = np.concatenate(all_target, axis=-1)
+    generated_ref_spect = np.concatenate(all_generated_ref, axis=-1)
+    generated_pred_spect = np.concatenate(all_generated_pred, axis=-1).squeeze(0)
+
+    fig = make_spectrogram_figure(target_spect, generated_ref_spect, generated_pred_spect)
+    tensorboard.add_figure(tag, fig, global_step=global_step)

--- a/src/utils/visualize.py
+++ b/src/utils/visualize.py
@@ -64,11 +64,11 @@ def visualize_model_approximation(
     voc_state_np = obs[ObsNames.VOC_STATE]
     generated_np = obs[ObsNames.GENERATED_SOUND_SPECTROGRAM]
 
-    target = torch.as_tensor(target_np, dtype=dtype, device=device)  # t_1
-    voc_state = torch.as_tensor(voc_state_np, dtype=dtype, device=device)  # v_0
-    generated_ref = torch.as_tensor(generated_np, dtype=dtype, device=device)  # g_0
+    target = torch.as_tensor(target_np, dtype=dtype, device=device).unsqueeze(0)  # t_1
+    voc_state = torch.as_tensor(voc_state_np, dtype=dtype, device=device).unsqueeze(0)  # v_0
+    generated_ref = torch.as_tensor(generated_np, dtype=dtype, device=device).unsqueeze(0)  # g_0
 
-    state = torch.zeros(world.prior.state_shape, dtype=dtype, device=device)  # s_0
+    state = torch.zeros((1, *world.prior.state_shape), dtype=dtype, device=device)  # s_0
 
     # init hidden for world model's prediction
     agent.reset()
@@ -76,7 +76,7 @@ def visualize_model_approximation(
 
     done = False
     while not done:
-        all_target.append(target)  # T_t+1
+        all_target.append(target_np)  # T_t+1
 
         # append prediction by world model
         action = agent.act(
@@ -96,9 +96,9 @@ def visualize_model_approximation(
         voc_state_np = obs[ObsNames.VOC_STATE]
         target_np = obs[ObsNames.TARGET_SOUND_SPECTROGRAM]  # T_t+2
 
-        generated_ref = torch.as_tensor(generated_ref_np, dtype=dtype, device=device)
-        target = torch.as_tensor(target_np, dtype=dtype, device=device)
-        voc_state = torch.as_tensor(voc_state_np, dtype=dtype, device=device)
+        generated_ref = torch.as_tensor(generated_ref_np, dtype=dtype, device=device).unsqueeze(0)
+        target = torch.as_tensor(target_np, dtype=dtype, device=device).unsqueeze(0)
+        voc_state = torch.as_tensor(voc_state_np, dtype=dtype, device=device).unsqueeze(0)
 
     target_spect = np.concatenate(all_target, axis=-1)
     generated_ref_spect = np.concatenate(all_generated_ref, axis=-1)

--- a/tests/models/test_dreamer.py
+++ b/tests/models/test_dreamer.py
@@ -7,6 +7,7 @@ from functools import partial
 import numpy as np
 import pytest
 import torch
+import torchaudio
 from gym.spaces import Box
 from pynktrombonegym.spaces import ObservationSpaceNames as OSN
 from pynktrombonegym.wrappers import ActionByAcceleration as ABA
@@ -121,8 +122,19 @@ def test__init__():
         else:
             assert False, f"attribute {attrs[idx]} doesn't set"
 
+    n_mfcc = 40
+    n_mels = 80
+    norm = "ortho"
     assert model.coef_latent_space_loss == 0.0
     assert model.coef_spectrogram_loss == 1.0
+    assert model.coef_mfcc_loss == 0.0
+    assert model.mfcc_lifter_size == 12
+
+    n_mfcc = 40
+    n_mels = 80
+    norm = "ortho"
+    dct_mat = torchaudio.functional.create_dct(n_mfcc, n_mels, norm)
+    torch.testing.assert_allclose(model.dct_mat, dct_mat)
 
 
 def test_configure_optimizers():

--- a/tests/utils/test_visualize.py
+++ b/tests/utils/test_visualize.py
@@ -1,0 +1,108 @@
+import glob
+import os
+import pathlib
+from datetime import datetime
+from functools import partial
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import torch
+from gym.spaces import Box
+from pynktrombonegym.spaces import ObservationSpaceNames as OSN
+from torch.optim import SGD
+from torch.utils.tensorboard import SummaryWriter
+
+from src.datamodules import buffer_names
+from src.datamodules.replay_buffer import ReplayBuffer
+from src.env.array_action import ARRAY_ORDER as AO_act
+from src.env.array_voc_state import ARRAY_ORDER as AO_voc
+from src.env.array_voc_state import VSON
+from src.env.make_env import make_env
+from src.models.dreamer import Dreamer
+from src.utils.visualize import make_spectrogram_figure, visualize_model_approximation
+from tests.models.abc.dummy_classes import DummyAgent as DA
+from tests.models.abc.dummy_classes import DummyController as DC
+from tests.models.abc.dummy_classes import DummyObservationDecoder as DOD
+from tests.models.abc.dummy_classes import DummyObservationEncoder as DOE
+from tests.models.abc.dummy_classes import DummyPrior as DP
+from tests.models.abc.dummy_classes import DummyTransition as DT
+from tests.models.abc.dummy_classes import DummyWorld as DW
+
+target_file_path = str(pathlib.Path(__file__).parents[2].joinpath("data/sample_target_sounds/"))
+env = make_env([target_file_path])
+
+hidden_shape = (16,)
+ctrl_hidden_shape = (16,)
+state_shape = (8,)
+action_shape = (len(AO_act),)
+
+obs_space = env.observation_space
+voc_stats_shape = obs_space[VSON.VOC_STATE].shape
+rnn_input_shape = (8,)
+
+gen_sound_shape = obs_space[OSN.GENERATED_SOUND_SPECTROGRAM].shape
+tgt_sound_shape = obs_space[OSN.TARGET_SOUND_SPECTROGRAM].shape
+obs_shape = (24,)
+
+obs_enc = DOE(state_shape, obs_shape)
+obs_dec = DOD(
+    voc_stats_shape,
+    gen_sound_shape,
+)
+prior = DP(state_shape)
+trans = DT(hidden_shape)
+ctrl = DC(action_shape, ctrl_hidden_shape)
+
+
+d_world = partial(DW)
+d_agent = partial(DA, action_shape=action_shape)
+
+world_opt = partial(SGD, lr=1e-3)
+ctrl_opt = partial(SGD, lr=1e-3)
+
+
+bf_size = 32
+bf_space = {
+    buffer_names.ACTION: Box(-np.inf, np.inf, action_shape),
+    buffer_names.DONE: Box(-np.inf, np.inf, (1,)),
+    buffer_names.GENERATED_SOUND: Box(-np.inf, np.inf, gen_sound_shape),
+    buffer_names.TARGET_SOUND: Box(-np.inf, np.inf, tgt_sound_shape),
+    buffer_names.VOC_STATE: Box(-np.inf, np.inf, voc_stats_shape),
+}
+args = (trans, prior, obs_enc, obs_dec, ctrl, d_world, d_agent, world_opt, ctrl_opt)
+del env
+
+tb_log_dir = f"logs/test_visualize/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
+
+
+def test_make_spectrogram_figure():
+    model = Dreamer(*args)
+    model.tensorboard = SummaryWriter(os.path.join(tb_log_dir, "test_log"))
+    shape = (128, 256)
+    gen_spect = np.random.rand(*shape)
+    tgt_spect = np.random.rand(*shape)
+    pred_gen_spect = np.random.rand(*shape)
+    tag = "evaluation_step/mel_spect/test"
+    for i in range(3):
+        fig: plt.figure = make_spectrogram_figure(tgt_spect, gen_spect, pred_gen_spect)
+        model.tensorboard.add_figure(tag, fig, global_step=i + 1)
+
+
+def test_visualize_model_approximation():
+    env = make_env([target_file_path])
+    model = Dreamer(*args)
+    tb = SummaryWriter(os.path.join(tb_log_dir, "test_log"))
+    world = model.world
+    agent = model.agent
+
+    for i in range(3):
+        visualize_model_approximation(
+            world,
+            agent,
+            env,
+            tb,
+            "evaluation_step/mel_spect/test",
+            i,
+        )
+    del env


### PR DESCRIPTION
## 概要
#99  MFCC損失を組み込んだ実験を行っていく上での更新と修正です。

## 変更内容
- DreamerにMFCC損失を実装しました。`coef_mfcc_loss`でその損失をスケーリングできるほか、`mfcc_lifter_size`を用いて低次元のMFCCチャネルだけを損失に組み込むことができます.
- Makefileに`docker-run-mount`コマンドを追加。ローカル環境でのマウント処理をしやすくしました。
- visualize.pyで発生したエラーを修正しました。
- torchaudioのcudaバージョンを11.6に修正しました。


<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲
- torchaudioとtorchのcudaバージョンの差異でエラーが出ているため、再インストールが必要になります。`poetry update torchaudio`で更新することができます。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
