### PR TITLE
Residual Connection 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# vscode
+.vscode/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}

--- a/src/models/components/res_layers.py
+++ b/src/models/components/res_layers.py
@@ -1,9 +1,9 @@
 import torch
 import torch.nn as nn
 
-class ResBlock(nn.Module):
 
-    def __init__(self, input_size: int, hidden_size:int, output_size: int, bias: bool=True):
+class ResBlock(nn.Module):
+    def __init__(self, input_size: int, hidden_size: int, output_size: int, bias: bool = True):
         super().__init__()
         self.fc1 = nn.Linear(input_size, hidden_size, bias)
         self.relu = nn.ReLU()
@@ -15,11 +15,18 @@ class ResBlock(nn.Module):
         hx = fx + x
         return hx
 
+
 class ResLayers(nn.Module):
     """Linearの幅と深さを変更できるクラス."""
 
     def __init__(
-        self, input_size: int, hidden_size: int, res_hidden_size:int, layers: int, output_size: int, bias: bool = True
+        self,
+        input_size: int,
+        hidden_size: int,
+        res_hidden_size: int,
+        layers: int,
+        output_size: int,
+        bias: bool = True,
     ) -> None:
         """
         Args:

--- a/src/models/components/res_layers.py
+++ b/src/models/components/res_layers.py
@@ -30,11 +30,12 @@ class ResLayers(nn.Module):
     ) -> None:
         """
         Args:
-            input_size (int):
-            hidden_size (int):
-            layers (int):
-            output_size (int):
-            bias (bool):
+            input_size (int): The size of input layers.
+            hidden_size (int): The size of hidden layers.
+            res_hidden_size: The size of hidden layers in ResBlock.
+            layers (int): The number of ResBlocks.
+            output_size (int): The size of output.
+            bias (bool): Whether you need bias or not in ResBlock.
         """
         super().__init__()
         self.input_layer = nn.Linear(input_size, hidden_size, bias=bias)

--- a/src/models/components/res_layers.py
+++ b/src/models/components/res_layers.py
@@ -34,7 +34,7 @@ class ResLayers(nn.Module):
 
         self.hidden_layers = nn.Sequential()
 
-        args = (hidden_size, hidden_size, res_hidden_size, bias)
+        args = (hidden_size, res_hidden_size, hidden_size, bias)
         for _ in range(layers):
             self.hidden_layers.append(ResBlock(*args))
             # self.hidden_layers.append(nn.LayerNorm(hidden_size))

--- a/src/models/components/res_layers.py
+++ b/src/models/components/res_layers.py
@@ -17,7 +17,7 @@ class ResBlock(nn.Module):
 
 
 class ResLayers(nn.Module):
-    """Linearの幅と深さを変更できるクラス."""
+    """ResBlocksの幅と深さと数を変更できるクラス."""
 
     def __init__(
         self,

--- a/src/models/components/res_layers.py
+++ b/src/models/components/res_layers.py
@@ -19,7 +19,7 @@ class ResLayers(nn.Module):
     """Linearの幅と深さを変更できるクラス."""
 
     def __init__(
-        self, input_size: int, hidden_size: int, layers: int, output_size: int, bias: bool = True
+        self, input_size: int, hidden_size: int, res_hidden_size:int, layers: int, output_size: int, bias: bool = True
     ) -> None:
         """
         Args:
@@ -34,7 +34,7 @@ class ResLayers(nn.Module):
 
         self.hidden_layers = nn.Sequential()
 
-        args = (hidden_size, hidden_size, hidden_size, bias)
+        args = (hidden_size, hidden_size, res_hidden_size, bias)
         for _ in range(layers):
             self.hidden_layers.append(ResBlock(*args))
             # self.hidden_layers.append(nn.LayerNorm(hidden_size))

--- a/src/models/components/res_layers.py
+++ b/src/models/components/res_layers.py
@@ -1,0 +1,63 @@
+import torch
+import torch.nn as nn
+
+class ResBlock(nn.Module):
+
+    def __init__(self, input_size: int, hidden_size:int, output_size: int, bias: bool=True):
+        super().__init__()
+        self.fc1 = nn.Linear(input_size, hidden_size, bias)
+        self.relu = nn.ReLU()
+        self.fc2 = nn.Linear(hidden_size, output_size, bias)
+
+    def forward(self, x):
+        fx = self.relu(self.fc1(x))
+        fx = self.fc2(fx)
+        hx = fx + x
+        return hx
+
+class ResLayers(nn.Module):
+    """Linearの幅と深さを変更できるクラス."""
+
+    def __init__(
+        self, input_size: int, hidden_size: int, layers: int, output_size: int, bias: bool = True
+    ) -> None:
+        """
+        Args:
+            input_size (int):
+            hidden_size (int):
+            layers (int):
+            output_size (int):
+            bias (bool):
+        """
+        super().__init__()
+        self.input_layer = nn.Linear(input_size, hidden_size, bias=bias)
+
+        self.hidden_layers = nn.Sequential()
+
+        args = (hidden_size, hidden_size, hidden_size, bias)
+        for _ in range(layers):
+            self.hidden_layers.append(ResBlock(*args))
+            # self.hidden_layers.append(nn.LayerNorm(hidden_size))
+            self.hidden_layers.append(nn.ReLU())
+
+        self.output_layer = nn.Linear(hidden_size, output_size, bias=bias)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Args:
+            x: input tensor
+
+        Returns:
+            output: output tensor
+        """
+
+        hidden_first = self.input_layer(x)
+
+        hidden_last = self.hidden_layers(hidden_first)
+
+        output = self.output_layer(hidden_last)
+
+        return output

--- a/src/models/components/res_stackings/controller.py
+++ b/src/models/components/res_stackings/controller.py
@@ -1,0 +1,117 @@
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+from ...abc.controller import Controller as AbsController
+from ..linear_layers import ResLayers
+from ..posterior_encoder_vits import PosteriorEncoderVITS
+
+
+class Controller(AbsController):
+    def __init__(
+        self,
+        encoder: PosteriorEncoderVITS,
+        hidden_size: int,
+        state_size: int,
+        c_hidden_size: int,
+        action_size: int,
+        input_size: int,
+        feats_T: int,
+        stacked_res_hidden_size: int,
+        num_layers: int = 1,
+        bias: bool = True,
+    ) -> None:
+        """
+        Args:
+            encoder (PosteriorEncoderVITS): target encoder module.
+            hidden_size (int): The size of hidden state(h_t) of RNN
+            state_size (int): The size of state(s_t)
+            c_hidden_size (int): The size of controller_hidden_state(hc_t) of RNN
+            action_size (int): The size of action(a_t)
+            input_size (int): Input dimension of RNN
+            stacked_res_hidden_size (int): The hidden size of `fc_input_layer`.
+            num_layers (int): The number of internal layers (For stacked linear).
+            bias (bool, optional): This argument determines whether RNN requires bias or not. Defaults to True.
+        """
+
+        # define target melspectrogram encoder
+        # define modules
+
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.state_size = state_size
+        self.encoder = encoder
+        self.feats_T = feats_T
+        self.c_hidden_size = c_hidden_size
+        self.stacked_res_hidden_size = stacked_res_hidden_size
+        self.num_layers = num_layers
+        self.action_size = action_size
+
+        self.fc_time_reduction = nn.Linear(feats_T, 1)
+
+        self.fc_input_layer = ResLayers(
+            hidden_size + state_size + state_size,  # hidden + obs_state + target_state
+            stacked_res_hidden_size,
+            num_layers,
+            input_size,
+            bias,
+        )
+
+        self.rnn = nn.GRUCell(
+            input_size=input_size,
+            hidden_size=c_hidden_size,
+            bias=bias,
+        )
+
+        self.fc_mean = nn.Linear(hidden_size, action_size, bias)
+        self.fc_logs = nn.Linear(hidden_size, action_size, bias)
+
+    def forward(
+        self,
+        hidden: Tensor,
+        state: Tensor,
+        target: Tensor,
+        controller_hidden: Tensor,
+        probabilistic: bool,
+    ) -> Tuple[Tensor, Tensor]:
+        """
+        Args:
+            hidden (Tensor):hidden state of RNN[B,hidden_size]
+            state (Tensor):state of Observation [B,state_size]
+            target (Tensor):target melspectrogram [B,in_channels, T_feats]
+            cotroller_hidden (Tensor):hidden state of controller RNN[B,c_hidden_size]
+            probabilistic (bool):  If True, sample action from normal distribution.
+
+        Returns:
+            action (Tensor): ction data `a_t`. The value range must be [-1, 1].
+            next_controller_hidden (Tensor): Next controller hidden state `hc_{t+1}`.
+        """
+        # target encoding
+        _, _m, _, _ = self.encoder(
+            target, torch.tensor([self.feats_T] * hidden.size(0), dtype=torch.float32)
+        )
+        target_state = self.fc_time_reduction(_m).squeeze(2)
+
+        # RNN
+        hidden_state = torch.cat((hidden, state), dim=1)
+        hidden_state_target = torch.cat((hidden_state, target_state), dim=1)
+
+        rnn_input = self.fc_input_layer(hidden_state_target)
+        next_controller_hidden = self.rnn(rnn_input, controller_hidden)
+
+        # action
+        m = self.fc_mean(next_controller_hidden)
+        logs = self.fc_logs(next_controller_hidden)
+
+        if probabilistic:
+            action = m + torch.randn_like(m) * torch.exp(logs)
+        else:
+            action = m
+
+        return torch.tanh(action), next_controller_hidden
+
+    @property
+    def controller_hidden_shape(self):
+        return (self.c_hidden_size,)

--- a/src/models/components/res_stackings/observation_auto_encoder.py
+++ b/src/models/components/res_stackings/observation_auto_encoder.py
@@ -6,8 +6,8 @@ from torch.distributions import Distribution, Normal
 from ...abc.observation_auto_encoder import ObservationDecoder as AbsObservationDecoder
 from ...abc.observation_auto_encoder import ObservationEncoder as AbsObservationEncoder
 from ..conformer_decoder_fastspeech2 import ConformerDecoder
-from ..res_layers import ResLayers
 from ..posterior_encoder_vits import PosteriorEncoderVITS
+from ..res_layers import ResLayers
 
 
 class ObservationEncoder(AbsObservationEncoder):

--- a/src/models/components/res_stackings/observation_auto_encoder.py
+++ b/src/models/components/res_stackings/observation_auto_encoder.py
@@ -1,0 +1,176 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributions import Distribution, Normal
+
+from ...abc.observation_auto_encoder import ObservationDecoder as AbsObservationDecoder
+from ...abc.observation_auto_encoder import ObservationEncoder as AbsObservationEncoder
+from ..conformer_decoder_fastspeech2 import ConformerDecoder
+from ..res_layers import ResLayers
+from ..posterior_encoder_vits import PosteriorEncoderVITS
+
+
+class ObservationEncoder(AbsObservationEncoder):
+    def __init__(
+        self,
+        mel_encoder: PosteriorEncoderVITS,
+        state_size: int,
+        hidden_size: int,
+        feats_T: int,
+        stacked_res_hidden_size: int,
+        num_layers: int = 1,
+        min_logs: float = 0.1,
+        bias: bool = True,
+    ) -> None:
+        """
+        Args:
+            mel_encoder (PosteriorEncoderVITS): Mel spectrogram encoder.
+            state_size (int): The size of state(s_t)
+            hidden_size (int): The size of hidden state(h_t)
+            feats_T (int): Time step length of mel spectrogram.
+            stacked_linear_hidden_size (int): The hidden size of `fc_input_layer`.
+            num_layers (int): The number of internal layers (For stacked linear).
+            min_logs (float, optional): inimum value of standard deviation. Defaults to 0.1.
+            bias (bool): Bias of `nn.Linear`.
+        """
+        super().__init__()
+
+        self.feats_T = feats_T
+        self.state_size = state_size
+        self.min_logs = min_logs
+
+        self.obs_embedding_layer = mel_encoder
+        self.time_reduction_layer = torch.nn.Linear(feats_T, 1)
+
+        self.fc_input_layer = ResLayers(
+            hidden_size + state_size,
+            stacked_res_hidden_size,
+            num_layers,
+            hidden_size,
+            bias,
+        )
+
+        self.fc_mean = nn.Linear(hidden_size, state_size, bias)
+        self.fc_logs = nn.Linear(hidden_size, state_size, bias)
+
+    def embed_observation(self, obs: torch.Tensor) -> torch.Tensor:
+        """Embed observation to latent space.
+
+        Args:
+            obs (_tensor_or_any): observation data.
+                For instance, obs=(voc state v_t, generated sound g_t) <- Tuple of Tensor!
+        Returns:
+            embedded_obs (_tensor_or_any): Embedded observation.
+        """
+        # vocal tract state embedding
+        vt, mel = obs
+        batch_size = mel.size(0)
+        _, m, _, _ = self.obs_embedding_layer(
+            x=mel,
+            x_lengths=torch.tensor([self.feats_T] * batch_size, dtype=torch.float32),
+            g=vt.unsqueeze(2),
+        )
+
+        embedded_obs = self.time_reduction_layer(m).squeeze(2)
+
+        return embedded_obs
+
+    def encode(self, hidden: torch.Tensor, embedded_obs: torch.Tensor) -> Distribution:
+        """Encode hidden state and embedded_obs to world 'state'.
+        Args:
+            hidden (_tensor_or_any): hidden state `h_t`
+            embedded_obs (_tensor_or_any): Embedded obsevation data.
+
+        Returns:
+            state (_t_or_any[Distribution]): world state `s_t`.
+                Type is `Distiribution` class for computing kl divergence.
+        """
+        x = torch.concat((hidden, embedded_obs), dim=1)
+        x = self.fc_input_layer(x)
+        mean = self.fc_mean(x)
+        logs = F.softplus(self.fc_logs(x)) + self.min_logs
+
+        return Normal(mean, logs)
+
+    @property
+    def state_shape(self) -> tuple[int]:
+        """Returns world 'state' shape.
+
+        Do not contain batch dim.
+        """
+        return (self.state_size,)
+
+
+class ObservationDecoder(AbsObservationDecoder):
+    def __init__(
+        self,
+        decoder: ConformerDecoder,
+        voc_state_size: int,
+        feats_T: int,
+        stacked_linear_hidden_size: int,
+        num_layers: int = 1,
+        conv_kernel_size: int = 3,
+        conv_padding_size: int = 1,
+        conv_bias: bool = True,
+    ) -> None:
+        """
+        Args:
+            decoder (ConformerDecoder): Decoder to reconstruct the mel spectrogram
+            voc_state_size (int): The size of vocal state array.
+            feats_T (int): Time step length of mel spectrogram.
+            stacked_linear_hidden_size (int): The hidden size of `fc_input_layer`.
+            num_layers (int): The number of internal layers (For stacked linear).
+            conv_kernel_size (int): Input convolution kernel size.
+            conv_padding_size (int): Input convolution padding size.
+            conv_bias (bool): Whether the input convolution has bias or not.
+            bias (bool): Bias of `nn.Linear`.
+        """
+        super().__init__()
+
+        # decoder input (hidden_size + stat_size)
+        self.decoder = decoder
+
+        self.time_extend_conv = torch.nn.Conv1d(
+            in_channels=1,
+            out_channels=feats_T,
+            kernel_size=conv_kernel_size,
+            padding=conv_padding_size,
+            bias=conv_bias,
+        )
+
+        self.voc_decoder = ResLayers(
+            input_size=self.decoder.idim,
+            hidden_size=stacked_linear_hidden_size,
+            layers=num_layers,
+            output_size=voc_state_size,
+        )
+
+    def forward(
+        self,
+        hidden: torch.Tensor,
+        state: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Decode to observation.
+
+        Args:
+            hidden (Tensor): hidden state `h_t`.
+            state (Tensor): world state `s_t`.
+        Returns:
+            obs (tuple[Tensor, Tensor]): reconstructed observation (o^_t).
+                obs=(voc state v_t, generated sound g_t) will be returned.
+        """
+        concat_input = torch.concat((hidden, state), dim=1)
+
+        time_extend_input = self.time_extend_conv(
+            concat_input.unsqueeze(1)  # (batch, 1, channels)
+        )
+
+        decoder_input = time_extend_input.transpose(1, 2)  # (batch, channels, feats_T)
+
+        reconst_mel = self.decoder(torch.relu(decoder_input))
+
+        reconst_voc = self.voc_decoder(concat_input)
+
+        reconst_obs = (reconst_voc, reconst_mel)
+
+        return reconst_obs

--- a/src/models/components/res_stackings/prior_encoder.py
+++ b/src/models/components/res_stackings/prior_encoder.py
@@ -1,0 +1,71 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributions import Distribution
+from torch.distributions.normal import Normal
+
+from ...abc.prior import Prior as AbstractPrior
+from ..res_layers import ResLayers
+
+
+class Prior(AbstractPrior):
+    def __init__(
+        self,
+        hidden_dim: int,
+        state_dim: int,
+        stacked_res_hidden_size: int,
+        num_layers: int = 1,
+        min_stddev: float = 0.1,
+        bias: bool = True,
+    ) -> None:
+        """
+        Args:
+            hidden_dim (int): The length of Hidden dimension
+            state_dim (int): The length of State dimension
+            stacked_linear_hidden_size (int): The hidden size of `fc_input_layer`.
+            num_layers (int): The number of internal layers (For stacked linear).
+            min_stddev (float, optional): inimum value of standard deviation. Defaults to 0.1.
+            bias (bool): Bias of `nn.Linear`.
+        """
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.state_dim = state_dim
+        self.min_stddev = min_stddev
+
+        assert hidden_dim > 0, "hidden_dim must be greater than 0"
+        assert state_dim > 0, "state_dim must be greater than 0"
+
+        self.fc_input_layer = ResLayers(
+            hidden_dim,
+            stacked_res_hidden_size,
+            num_layers,
+            hidden_dim,
+            bias,
+        )
+
+        self.fc_to_mean = nn.Linear(hidden_dim, state_dim, bias)
+        self.fc_to_stddev = nn.Linear(hidden_dim, state_dim, bias)
+
+    def forward(self, hidden: torch.Tensor) -> Distribution:
+        """
+        Args:
+            hidden (Tensor): Hidden vectors computed deterministically.
+
+        Returns:
+            state (Distribution) : The Normal distribution
+        """
+        hidden = self.fc_input_layer(hidden)
+        mean = self.fc_to_mean(hidden)
+        stddev = (
+            F.softplus(self.fc_to_stddev(hidden)) + self.min_stddev
+        )  # Follows the code of exercise7
+        return Normal(mean, stddev)
+
+    @property
+    def state_shape(self) -> tuple[int]:
+        """The getter of the shape of state.
+
+        Returns:
+            tuple[int]: The size of state dimension.
+        """
+        return (self.state_dim,)

--- a/src/models/components/res_stackings/transition.py
+++ b/src/models/components/res_stackings/transition.py
@@ -1,0 +1,68 @@
+import torch
+from torch import Tensor, nn
+
+from ...abc.transition import Transition as AbstractTransition
+from ..res_layers import ResLayers
+
+
+class Transition(AbstractTransition):
+    def __init__(
+        self,
+        hidden_size: int,
+        state_size: int,
+        action_size: int,
+        input_size: int,
+        stacked_res_hidden_size: int,
+        num_layers: int = 1,
+        bias: bool = True,
+    ):
+        """
+        Args:
+            hidden_size (int): The size of hidden state(h_t) of RNN
+            state_size (int): The size of state(s_t)
+            action_size (int): The size of action(a_t)
+            input_size (int): The size of vector input to RNN
+            stacked_linear_hidden_size (int): The hidden size of `fc_input_layer`.
+            num_layers (int): The number of internal layers (For stacked linear).
+            bias (bool, optional): This argument determines whether RNN requires bias or not. Defaults to True.
+        """
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.state_size = state_size
+        self.action_size = action_size
+        self.input_size = input_size
+        self.stacked_res_hidden_size = stacked_res_hidden_size
+        self.bias = bias
+
+        self.fc_action_state = ResLayers(
+            self.state_size + self.action_size,
+            stacked_res_hidden_size,
+            num_layers,
+            input_size,
+            bias,
+        )
+
+        self.rnn = nn.GRUCell(
+            input_size=self.input_size,
+            hidden_size=self.hidden_size,
+            bias=bias,
+        )
+
+    def forward(self, hidden: Tensor, state: Tensor, action: Tensor) -> Tensor:
+        """Method for computing f(h_t, s_t, a_t) -> h_t+1.
+
+        Args:
+            hidden (Tensor): hidden state of RNN(h_t)
+            state (Tensor): state of Observation (s_t)
+            action (Tensor): action (a_t)
+
+        Returns:
+            Tensor: next hidden state of RNN(h_t+1)
+        """
+        rnn_input = self.fc_action_state(torch.cat((state, action), dim=-1))
+        next_hidden = self.rnn(rnn_input, hidden)
+        return next_hidden
+
+    @property
+    def hidden_shape(self) -> tuple[int]:
+        return (self.hidden_size,)

--- a/src/utils/visualize.py
+++ b/src/utils/visualize.py
@@ -14,7 +14,7 @@ def make_spectrogram_figure(
     target: np.ndarray,
     generated: np.ndarray,
     generated_prior: np.ndarray,
-    generated_posterior: np.ndarray
+    generated_posterior: np.ndarray,
 ) -> None:
     fig, axes = plt.subplots(4, 1)
     fig.tight_layout()
@@ -24,7 +24,7 @@ def make_spectrogram_figure(
         "Target": target,
         "Generated": generated,
         "Prediction(prior)": generated_prior,
-        "Prediction(posterior)": generated_posterior
+        "Prediction(posterior)": generated_posterior,
     }
     # show target mel spectrogram
     for i, (title, spect) in enumerate(data.items()):
@@ -60,7 +60,7 @@ def visualize_model_approximation(
     all_target = []
     all_generated_ref = []
     all_generated_prior = []
-    all_generated_posterior=[]
+    all_generated_posterior = []
     obs = env.reset()
 
     target_np = obs[ObsNames.TARGET_SOUND_SPECTROGRAM]
@@ -106,8 +106,10 @@ def visualize_model_approximation(
 
         # append prediction via posterior
         observation = (voc_state, generated_ref)
-        state_posterior = world.obs_encoder(hidden, observation).sample() # s_t+1(posterior)
-        _, generated_pred_posterior = world.obs_decoder(hidden, state_posterior) # g_t+1(posterior)
+        state_posterior = world.obs_encoder(hidden, observation).sample()  # s_t+1(posterior)
+        _, generated_pred_posterior = world.obs_decoder(
+            hidden, state_posterior
+        )  # g_t+1(posterior)
         all_generated_posterior.append(generated_pred_posterior.cpu().numpy())
 
     target_spect = np.concatenate(all_target, axis=-1)
@@ -115,5 +117,7 @@ def visualize_model_approximation(
     generated_prior_spect = np.concatenate(all_generated_prior, axis=-1).squeeze(0)
     generated_posterior_spect = np.concatenate(all_generated_posterior, axis=-1).squeeze(0)
 
-    fig = make_spectrogram_figure(target_spect, generated_ref_spect, generated_prior_spect, generated_posterior_spect)
+    fig = make_spectrogram_figure(
+        target_spect, generated_ref_spect, generated_prior_spect, generated_posterior_spect
+    )
     tensorboard.add_figure(tag, fig, global_step=global_step)

--- a/tests/models/components/res_stackings/test_controller.py
+++ b/tests/models/components/res_stackings/test_controller.py
@@ -1,0 +1,68 @@
+import pytest
+import torch
+
+from src.models.components.linear_stackings.controller import Controller
+from src.models.components.posterior_encoder_vits import PosteriorEncoderVITS
+
+
+@pytest.mark.parametrize(
+    """
+    batch_size,
+    hidden_size,
+    state_size,
+    target_mel_channels,
+    feats_T,
+    c_hidden_size,
+    action_size,
+    stacked_linear_hidden_size,
+    num_layers,
+    prob
+    """,
+    [
+        (1, 192, 192, 80, 5, 192, 7, 128, 1, False),
+        (5, 12, 12, 80, 5, 12, 44, 128, 3, True),
+    ],
+)
+def test_controller(
+    batch_size: int,
+    hidden_size: int,
+    state_size: int,
+    target_mel_channels: int,
+    feats_T: int,
+    c_hidden_size: int,
+    action_size: int,
+    stacked_linear_hidden_size: int,
+    num_layers: int,
+    prob: bool,
+):
+    # define encoder_modules
+    pos_enc_vits = PosteriorEncoderVITS(
+        in_channels=target_mel_channels, hidden_channels=state_size, out_channels=state_size
+    )
+
+    # controller instanse
+    input_size = 100
+    controller = Controller(
+        encoder=pos_enc_vits,
+        hidden_size=hidden_size,
+        state_size=state_size,
+        c_hidden_size=c_hidden_size,
+        action_size=action_size,
+        input_size=input_size,
+        feats_T=feats_T,
+        stacked_linear_hidden_size=stacked_linear_hidden_size,
+        num_layers=num_layers,
+        bias=True,
+    )
+
+    # create random tensor
+    hidden = torch.randn(batch_size, hidden_size)
+    state = torch.randn(batch_size, state_size)
+    target = torch.randn(batch_size, target_mel_channels, feats_T)
+    assert target.transpose(1, 2).size() == torch.Size([batch_size, feats_T, target_mel_channels])
+    c_hidden = torch.randn(batch_size, c_hidden_size)
+
+    action, next_controller_hidden = controller(hidden, state, target, c_hidden, prob)
+
+    assert next_controller_hidden.size() == torch.Size([batch_size, c_hidden_size])
+    assert action.size() == torch.Size([batch_size, action_size])

--- a/tests/models/components/res_stackings/test_observation_auto_encoder.py
+++ b/tests/models/components/res_stackings/test_observation_auto_encoder.py
@@ -1,0 +1,111 @@
+import pytest
+import torch
+
+from src.models.components.conformer_decoder_fastspeech2 import ConformerDecoder
+from src.models.components.linear_stackings.observation_auto_encoder import (
+    ObservationDecoder,
+    ObservationEncoder,
+)
+from src.models.components.posterior_encoder_vits import PosteriorEncoderVITS
+
+
+@pytest.mark.parametrize(
+    """
+    batch_size,
+    hidden_size,
+    state_size,
+    v_channels,
+    mel_channels,
+    feats_T,
+    stacked_linear_hidden_size,
+    num_layers,
+    """,
+    [(1, 192, 192, 75, 80, 5, 128, 2)],
+)
+def test_observation_encoder(
+    batch_size: int,
+    hidden_size: int,
+    state_size: int,
+    v_channels: int,
+    mel_channels: int,
+    feats_T: int,
+    stacked_linear_hidden_size: int,
+    num_layers: int,
+):
+    # instance posterior encoder
+    mel_encoder = PosteriorEncoderVITS(
+        in_channels=mel_channels,
+        out_channels=state_size,
+        hidden_channels=state_size,
+        global_channels=v_channels,
+    )
+
+    # instance observation encoder
+    obs_encoder = ObservationEncoder(
+        mel_encoder=mel_encoder,
+        state_size=state_size,
+        hidden_size=hidden_size,
+        feats_T=feats_T,
+        stacked_linear_hidden_size=stacked_linear_hidden_size,
+        num_layers=num_layers,
+    )
+
+    # create input
+    v_t = torch.rand((batch_size, v_channels))
+    mel = torch.rand((batch_size, mel_channels, feats_T))
+    hidden = torch.rand((batch_size, hidden_size))
+
+    obs = (v_t, mel)
+
+    state = obs_encoder(hidden, obs)
+
+    assert state.sample().size() == torch.Size([batch_size, state_size])
+
+
+@pytest.mark.parametrize(
+    """
+    batch_size,
+    hidden_size,
+    state_size,
+    v_channels,
+    mel_channels,
+    feats_T,
+    stacked_linear_hidden_size,
+    """,
+    [(1, 192, 192, 75, 80, 5, 128)],
+)
+def test_observation_decoder(
+    batch_size: int,
+    hidden_size: int,
+    state_size: int,
+    v_channels: int,
+    mel_channels: int,
+    feats_T: int,
+    stacked_linear_hidden_size: int,
+):
+    # instance posterior encoder
+    idim = hidden_size + state_size
+    conformer_decoder = ConformerDecoder(idim=idim, odim=mel_channels, adim=idim)
+
+    # instance observation encoder
+    obs_decoder = ObservationDecoder(
+        decoder=conformer_decoder,
+        feats_T=feats_T,
+        voc_state_size=v_channels,
+        stacked_linear_hidden_size=stacked_linear_hidden_size,
+        num_layers=3,
+    )
+
+    # create input
+    hidden = torch.rand((batch_size, hidden_size))
+    state = torch.rand((batch_size, state_size))
+
+    reconst_obs = obs_decoder(
+        hidden,
+        state,
+    )
+
+    _voc, _mel = reconst_obs
+
+    assert _mel.size() == torch.Size([batch_size, mel_channels, feats_T])
+    assert _voc.size() == torch.Size([batch_size, v_channels])

--- a/tests/models/components/res_stackings/test_prior_encoder.py
+++ b/tests/models/components/res_stackings/test_prior_encoder.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+
+from src.models.components.linear_stackings.prior_encoder import Prior
+
+hidden_dim = 10
+invalid_hidden_dim = -1
+state_dim = 5
+invalid_state_dim = -1
+batch_size = 4
+stacked_linear_hidden_size = 16
+num_layers = 2
+
+
+def test__init__():
+    Prior(hidden_dim, state_dim, stacked_linear_hidden_size, num_layers)
+
+    with pytest.raises(AssertionError):
+        model = Prior(invalid_hidden_dim, state_dim, stacked_linear_hidden_size)
+    with pytest.raises(AssertionError):
+        model = Prior(hidden_dim, invalid_state_dim, stacked_linear_hidden_size)
+
+
+def test_forward():
+    model = Prior(hidden_dim, state_dim, stacked_linear_hidden_size)
+    # single input
+    random_input = torch.rand((hidden_dim,), requires_grad=True)
+    state_distribution = model(random_input)
+    assert state_distribution.sample().shape == (state_dim,)
+    assert state_distribution.rsample().requires_grad
+
+    # batch input
+    random_input = torch.rand((batch_size, hidden_dim), requires_grad=True)
+    state_distribution = model(random_input)
+    assert state_distribution.sample().shape == (batch_size, state_dim)
+    assert state_distribution.rsample().requires_grad
+
+
+def test_state_shape():
+    model = Prior(hidden_dim, state_dim, stacked_linear_hidden_size)
+    assert model.state_shape == (state_dim,)

--- a/tests/models/components/res_stackings/test_transition.py
+++ b/tests/models/components/res_stackings/test_transition.py
@@ -1,0 +1,54 @@
+import torch
+
+from src.models.components.linear_stackings.transition import Transition
+
+hidden_size = 10
+action_size = 8
+state_size = 8
+input_size = 8
+batch_size = 4
+stacked_linear_hidden_size = 16
+num_layers = 3
+
+args = {
+    "hidden_size": hidden_size,
+    "action_size": action_size,
+    "state_size": state_size,
+    "input_size": input_size,
+    "stacked_linear_hidden_size": stacked_linear_hidden_size,
+    "num_layers": num_layers,
+}
+
+
+def test__init__():
+    model = Transition(**args)
+
+    assert model.hidden_size == hidden_size
+    assert model.action_size == action_size
+    assert model.state_size == state_size
+    assert model.input_size == input_size
+    assert model.stacked_linear_hidden_size == stacked_linear_hidden_size
+
+
+def test_forward():
+    model = Transition(**args)
+
+    # single input
+    random_state = torch.rand(state_size)
+    random_action = torch.rand(action_size)
+    random_hidden = torch.rand(hidden_size)
+    next_hidden = model(random_hidden, random_state, random_action)
+    assert next_hidden.shape == (hidden_size,)
+
+    # batch input
+    random_state = torch.rand((batch_size, state_size))
+    random_action = torch.rand((batch_size, action_size))
+    random_hidden = torch.rand((batch_size, hidden_size))
+    next_hidden = model(random_hidden, random_state, random_action)
+    assert next_hidden.size(-1) == hidden_size
+    assert next_hidden.size(0) == batch_size
+
+
+def test_hidden_shape():
+    model = Transition(**args)
+    assert model.hidden_shape == (hidden_size,)

--- a/tests/models/test_res_layers.py
+++ b/tests/models/test_res_layers.py
@@ -11,13 +11,13 @@ def test_res_block():
     assert mod.relu is not None
     assert mod.fc2 is not None
 
-    x = torch.rand(1, 1, in_size) # 3 dim tensor
+    x = torch.randn(1, 1, in_size) # 3 dim tensor
     out = mod(x)
     assert out.size(-1) == out_size
 
 @pytest.mark.parametrize("layers", [1, 3])
 def test_res_layers(layers):
     mod = ResLayers(in_size, hid_size, layers, out_size)    
-    x = torch.rand(1, 1, in_size) # 3 dim tensor
+    x = torch.randn(1, 1, in_size) # 3 dim tensor
     out = mod(x)
     assert out.size(-1) == out_size

--- a/tests/models/test_res_layers.py
+++ b/tests/models/test_res_layers.py
@@ -1,10 +1,13 @@
 import pytest
 import torch
+
 from src.models.components.res_layers import ResBlock, ResLayers
+
 in_size = 4
 hid_size = 3
 res_h_size = 2
 out_size = 4
+
 
 def test_res_block():
     mod = ResBlock(hid_size, res_h_size, hid_size)
@@ -12,13 +15,14 @@ def test_res_block():
     assert mod.relu is not None
     assert mod.fc2 is not None
 
-    x = torch.rand(1, 1, hid_size) # 3 dim tensor
+    x = torch.rand(1, 1, hid_size)  # 3 dim tensor
     out = mod(x)
     assert out.size(-1) == hid_size
 
+
 @pytest.mark.parametrize("layers", [1, 3])
 def test_res_layers(layers):
-    mod = ResLayers(in_size, hid_size, res_h_size, layers, out_size)    
-    x = torch.rand(1, 1, in_size) # 3 dim tensor
+    mod = ResLayers(in_size, hid_size, res_h_size, layers, out_size)
+    x = torch.rand(1, 1, in_size)  # 3 dim tensor
     out = mod(x)
     assert out.size(-1) == out_size

--- a/tests/models/test_res_layers.py
+++ b/tests/models/test_res_layers.py
@@ -1,23 +1,24 @@
 import pytest
 import torch
 from src.models.components.res_layers import ResBlock, ResLayers
-in_size = 3
-hid_size = 2
-out_size = 3
+in_size = 4
+hid_size = 3
+res_h_size = 2
+out_size = 4
 
 def test_res_block():
-    mod = ResBlock(in_size, hid_size, out_size)
+    mod = ResBlock(hid_size, res_h_size, hid_size)
     assert mod.fc1 is not None
     assert mod.relu is not None
     assert mod.fc2 is not None
 
-    x = torch.rand(1, 1, in_size) # 3 dim tensor
+    x = torch.rand(1, 1, hid_size) # 3 dim tensor
     out = mod(x)
-    assert out.size(-1) == out_size
+    assert out.size(-1) == hid_size
 
 @pytest.mark.parametrize("layers", [1, 3])
 def test_res_layers(layers):
-    mod = ResLayers(in_size, hid_size, layers, out_size)    
+    mod = ResLayers(in_size, hid_size, res_h_size, layers, out_size)    
     x = torch.rand(1, 1, in_size) # 3 dim tensor
     out = mod(x)
     assert out.size(-1) == out_size

--- a/tests/models/test_res_layers.py
+++ b/tests/models/test_res_layers.py
@@ -1,0 +1,23 @@
+import pytest
+import torch
+from src.models.components.res_layers import ResBlock, ResLayers
+in_size = 3
+hid_size = 2
+out_size = 3
+
+def test_res_block():
+    mod = ResBlock(in_size, hid_size, out_size)
+    assert mod.fc1 is not None
+    assert mod.relu is not None
+    assert mod.fc2 is not None
+
+    x = torch.rand(1, 1, in_size) # 3 dim tensor
+    out = mod(x)
+    assert out.size(-1) == out_size
+
+@pytest.mark.parametrize("layers", [1, 3])
+def test_res_layers(layers):
+    mod = ResLayers(in_size, hid_size, layers, out_size)    
+    x = torch.rand(1, 1, in_size) # 3 dim tensor
+    out = mod(x)
+    assert out.size(-1) == out_size


### PR DESCRIPTION
## 概要
#108 
`linear_stacking` を単純に積み重ねると訓練誤差が増加する   
これを解消するためにResidual Connectionを導入したい。  
![image](https://user-images.githubusercontent.com/83456982/221801595-6b1febe2-5e58-4a13-87fd-974cbd25514f.png)

<!-- 変更の目的 もしくは 関連する Issue 番号 -->

## 変更内容
- src/models/components/res_layers.py  
- src/models/components/res_stackings  
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲
未導入のため上記以外なし  
<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
